### PR TITLE
Install instructions - how to choose a pyqt backend instead of pyside2

### DIFF
--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -45,6 +45,15 @@ If you installed napari with `pip` you can upgrade by calling
 $ pip install napari --upgrade
 ```
 
+## choosing a different backend
+By default, napari uses [PySide2](https://wiki.qt.io/Qt_for_Python). This is what most users will want. 
+
+If you want to use [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) instead for your backend, you can run these lines after installing napari:
+```
+pip uninstall pyside2 -y
+pip install pyqt5
+```
+
 ## troubleshooting
 
 We're currently working on improving our Windows support. Right now for some older Windows systems we have a known issue which we are working to resolve that causes the following error message:


### PR DESCRIPTION
I want to add this to the docs because there's confusion around how to choose a pyqt backend instead of pyside2 for napari. Currently, [this is the recommended method](https://github.com/napari/napari/issues/1026#issuecomment-595572305):
```
pip install napari
pip uninstall pyside2 -y
pip install pyqt5
```

I think this is important because occasionally you see a suggestion for `pip install napari[pyqt]`, which isn't currently supported (but also won't raise any kind of error, just like `pip install napari[anything-that-does-not-exist]`) 