### PR TITLE
Update Install docs again - how to choose a pyqt backend instead of pyside2

### DIFF
--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -51,9 +51,10 @@ Most users can safely ignore this section. If, however, you aim to use napari to
 
 [Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
 
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari like this:
 ```
-pip install pyqt5 napari
+pip install pyqt5
+pip install napari
 ```
 
 **Note**: the order of the packages in the above line is important, because [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -45,7 +45,7 @@ If you installed napari with `pip` you can upgrade by calling
 $ pip install napari --upgrade
 ```
 
-## choosing different Qt backends
+## choosing different python bindings for Qt
 
 Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer that Qt backend, read on.
 

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -26,11 +26,7 @@ The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and t
 pip install pyqt5 napari
 ```
 
-Note: the order of installation is important, [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari. During installation napari checks whether [pyqt5](https://pypi.org/project/PyQt5/) is already available. 
-If  so, napari will use a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend. 
-If there is no pre-existing installation of [pyqt5](https://pypi.org/project/PyQt5/), then napari will install and use 
-a [PySide2](https://wiki.qt.io/Qt_for_Python) backend. 
-This is the default, and fine for most users. 
+**Note**: the order of the packages in the above line is important, because [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.
 
 
 ### install from the master branch on Github

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -15,9 +15,13 @@ This tutorial will teach you how to do a clean install of **napari**. It is aime
 $ pip install napari
 ```
 
-### choosing differnt backends
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), which is fine for most users. A small percentage of users may wish to use a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend instead. 
-If you want to install napari with a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend with a single line command, you can use:
+### choosing different Qt backends
+
+Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer that Qt backend, read on.
+
+[Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
+
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari`. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
 ```
 pip install pyqt5 napari
 ```

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -51,13 +51,31 @@ Most users can safely ignore this section. If, however, you aim to use napari to
 
 [Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
 
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari like this:
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install pyqt5 and napari from PyPI like this.
+
+Installing napari from PyPI, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
 ```
 pip install pyqt5
 pip install napari
 ```
 
-**Note**: the order of the packages in the above line is important, because [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.
+**Note: The order of installing packages is important, [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.**
+
+If you would like install napari from the git repository instead, and use [pyqt5](https://pypi.org/project/PyQt5/) instead of [PySide2](https://wiki.qt.io/Qt_for_Python), then you also need to use the pip argument `--no-use-pep517`.
+
+Installing napari from a remote github repository, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
+```
+pip install pyqt5
+pip install --no-use-pep517 git+https://github.com/napari/napari
+```
+
+Installing napari from a cloned napari repository on your local machine, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
+```
+pip install pyqt5
+pip install --no-use-pep517 path_to_napari
+```
+
+**Note 2**: Developers who want an *editable* installation can add the `-e` flag, eg: `pip install -e --no-use-pep517 path_to_napari`. Replace `path_to_napari` with the actual path to the napari repository on your local machine.
 
 ## troubleshooting
 

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -15,20 +15,6 @@ This tutorial will teach you how to do a clean install of **napari**. It is aime
 $ pip install napari
 ```
 
-### choosing different Qt backends
-
-Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer that Qt backend, read on.
-
-[Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
-
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari`. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
-```
-pip install pyqt5 napari
-```
-
-**Note**: the order of the packages in the above line is important, because [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.
-
-
 ### install from the master branch on Github
 To get the most up to date version of through pip call
 ```sh
@@ -58,6 +44,19 @@ If you installed napari with `pip` you can upgrade by calling
 ```sh
 $ pip install napari --upgrade
 ```
+
+## choosing different Qt backends
+
+Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer that Qt backend, read on.
+
+[Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
+
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari`. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
+```
+pip install pyqt5 napari
+```
+
+**Note**: the order of the packages in the above line is important, because [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari.
 
 ## troubleshooting
 

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -51,7 +51,7 @@ Most users can safely ignore this section. If, however, you aim to use napari to
 
 [Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
 
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari`. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install napari with this single command:
 ```
 pip install pyqt5 napari
 ```

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -47,13 +47,13 @@ $ pip install napari --upgrade
 
 ## choosing different python bindings for Qt
 
-Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer that Qt backend, read on.
+Most users can safely ignore this section. If, however, you aim to use napari together with software that uses PyQt5, or have some other reason to prefer specific bindings to the Qt backend, read on.
 
-[Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we call in the context of napari a *backend*.
+[Qt](https://www.qt.io) is a C++ library that provides unified graphical user interface (GUI) elements and interactivity across platforms and operating systems. Several libraries exist for accessing these elements from Python, which we'll call python bindings for Qt. You are able to choose between several different python bindings for Qt, because napari itself uses [qtpy](https://github.com/spyder-ide/qtpy) as an interface that many different python bindings for Qt can fit into.
 
-The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), and this is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do not have [pyqt5](https://pypi.org/project/PyQt5/) installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) as the backend instead, you can install pyqt5 and napari from PyPI like this.
+The default python binding to Qt in napari is [PySide2](https://wiki.qt.io/Qt_for_Python). This is what you get if you type `pip install napari` or `conda install -c conda-forge napari` and you do *not* have [pyqt5](https://pypi.org/project/PyQt5/) already installed. If you wish to use [PyQt5](https://www.riverbankcomputing.com/software/pyqt/intro) for your python binding to Qt instead, install both pyqt5 and napari from PyPI like this.
 
-Installing napari from PyPI, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
+Installing napari from PyPI, using [pyqt5](https://pypi.org/project/PyQt5/) bindings for the Qt backend:
 ```
 pip install pyqt5
 pip install napari
@@ -63,13 +63,13 @@ pip install napari
 
 If you would like install napari from the git repository instead, and use [pyqt5](https://pypi.org/project/PyQt5/) instead of [PySide2](https://wiki.qt.io/Qt_for_Python), then you also need to use the pip argument `--no-use-pep517`.
 
-Installing napari from a remote github repository, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
+Installing napari from a remote github repository, using [pyqt5](https://pypi.org/project/PyQt5/) bindings for the Qt backend:
 ```
 pip install pyqt5
 pip install --no-use-pep517 git+https://github.com/napari/napari
 ```
 
-Installing napari from a cloned napari repository on your local machine, using a [pyqt5](https://pypi.org/project/PyQt5/) backend:
+Installing napari from a cloned napari repository on your local machine, using [pyqt5](https://pypi.org/project/PyQt5/) bindings for the Qt backend:
 ```
 pip install pyqt5
 pip install --no-use-pep517 path_to_napari

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -15,6 +15,20 @@ This tutorial will teach you how to do a clean install of **napari**. It is aime
 $ pip install napari
 ```
 
+### choosing differnt backends
+The default napari backend is [PySide2](https://wiki.qt.io/Qt_for_Python), which is fine for most users. A small percentage of users may wish to use a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend instead. 
+If you want to install napari with a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend with a single line command, you can use:
+```
+pip install pyqt5 napari
+```
+
+Note: the order of installation is important, [pyqt5](https://pypi.org/project/PyQt5/) must be installed *before* napari. During installation napari checks whether [pyqt5](https://pypi.org/project/PyQt5/) is already available. 
+If  so, napari will use a [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) backend. 
+If there is no pre-existing installation of [pyqt5](https://pypi.org/project/PyQt5/), then napari will install and use 
+a [PySide2](https://wiki.qt.io/Qt_for_Python) backend. 
+This is the default, and fine for most users. 
+
+
 ### install from the master branch on Github
 To get the most up to date version of through pip call
 ```sh
@@ -43,15 +57,6 @@ An empty napari viewer should appear as follows
 If you installed napari with `pip` you can upgrade by calling
 ```sh
 $ pip install napari --upgrade
-```
-
-## choosing a different backend
-By default, napari uses [PySide2](https://wiki.qt.io/Qt_for_Python). This is what most users will want. 
-
-If you want to use [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro) instead for your backend, you can run these lines after installing napari:
-```
-pip uninstall pyside2 -y
-pip install pyqt5
 ```
 
 ## troubleshooting


### PR DESCRIPTION
**Do not merge until after the next release of napari is available** (that should be release 0.3)

This pull request keeps our documentation in-sync with behaviour of the main napari repo.

In the main napari repo a PR https://github.com/napari/napari/pull/1059 has just been merged. That PR means that a new napari install will check to see if pyqt5 is already installed. If pyqt5 is found then napari will use a PyQt backend, and if it is not found then napari will install and use PySide2 instead.



