### PR TITLE
Add semantic linebreaks, fix typos and linting

### DIFF
--- a/applications/annotate_points.md
+++ b/applications/annotate_points.md
@@ -9,10 +9,10 @@ im_path = '<path to directory with data>/*.png'
 point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'])
 
 ```
+
 The resulting viewer looks like this (images from [Mathis et al., 2018](https://www.nature.com/articles/s41593-018-0209-y), downloaded from [here](https://github.com/DeepLabCut/DeepLabCut/tree/f21321ef8060c537f9df0ce9346189bda07701b5/examples/openfield-Pranav-2018-10-30/labeled-data/m4s1)):
 
 ![image]({{ '/assets/tutorials/point_annotator_demo.gif' | relative_url }})
-
 
 You can explore the project in [this repository](https://github.com/kevinyamauchi/PointAnnotator) or check out the main function below. We will walk through the code in the following sections.
 
@@ -117,15 +117,16 @@ def point_annotator(
             new_label = labels[new_ind]
             current_properties['label'] = np.array([new_label])
             points_layer.current_properties = current_properties
-        
 ```
+
 ## point_annotator()
+
 We will create the GUI within a function called `point_annotator()`. Wrapping the GUI creation in the function allows us to integrate it into other functions (e.g., a command line interface) and applications. See below for the function definition.
 
 ```python
 def point_annotator(
-	im_path: str,
-	labels: List[str],
+    im_path: str,
+    labels: List[str],
 ):
     """Create a GUI for annotating points in a series of images.
 
@@ -140,6 +141,7 @@ def point_annotator(
 ```
 
 ## Loading the video
+
 First, we load the movie to be annotated. Since behavior movies can be quite long, we will use a lazy loading strategy (i.e., we will only load the frames as they are used). Using [`dask-image`](https://github.com/dask/dask-image), we can construct an object that we can pass to napari for lazy loading in just one line. For more explanation on using dask to lazily load images in napari, see [this](https://napari.org/tutorials/applications/dask) tutorial.
 
 ```python
@@ -154,8 +156,8 @@ with napari.gui_qt():
 ```
 
 ## Annotating with points
-We will annotate the features of interest using points in a napari Points layer. Each feature will be given a different label so that we can track them across frames. To achieve this, we will store the label in the `Points.properties` property in the 'label' key. We will instantiate the `Points` layer without any points. However, we will initialize `Points.properties` with the property values we will be using to annotate the images. To do so, we will define a properties dictionary with a key named `label` and values `labels`. The key, 'label', is the name of the property we are storing which feature of interest each point corresponds with. The values, 'labels', is the list of the names of the features we will be annotating (defined above in the "point_annotator()" section). 
 
+We will annotate the features of interest using points in a napari Points layer. Each feature will be given a different label so that we can track them across frames. To achieve this, we will store the label in the `Points.properties` property in the 'label' key. We will instantiate the `Points` layer without any points. However, we will initialize `Points.properties` with the property values we will be using to annotate the images. To do so, we will define a properties dictionary with a key named `label` and values `labels`. The key, 'label', is the name of the property we are storing which feature of interest each point corresponds with. The values, 'labels', is the list of the names of the features we will be annotating (defined above in the "point_annotator()" section). 
 
 We add the points layer to the viewer using the `viewer.add_points()` method. As discussed above, we will be storing which feature of interest each points corresponds to via the `label` property we defined in the `properties` dictionary. To visualize the feature each points represent, we set the edge color as a color cycle mapped to the `label` property (`edge_color='label'`). 
 
@@ -176,26 +178,27 @@ Note that we set the `edge_color_cycle` to `COLOR_CYCLE`. You can define your ow
 
 ```python
 COLOR_CYCLE = [
-	'#1f77b4',
-	'#ff7f0e',
-	'#2ca02c',
-	'#d62728',
-	'#9467bd',
-	'#8c564b',
-	'#e377c2',
-	'#7f7f7f',
-	'#bcbd22',
-	'#17becf'
+    '#1f77b4',
+    '#ff7f0e',
+    '#2ca02c',
+    '#d62728',
+    '#9467bd',
+    '#8c564b',
+    '#e377c2',
+    '#7f7f7f',
+    '#bcbd22',
+    '#17becf'
 ]
 ```
 
 Finally, we set the edge color to a color cycle:
 
 ```python
-	points_layer.edge_color_mode = 'cycle'
+    points_layer.edge_color_mode = 'cycle'
 ```
 
 ## Adding a GUI for selecting points
+
 First, we will define a function outside of the `napari.gui_qt()` context to create a GUI for select the labels for points. The function `create_label_menu()` will take the points layer we created and the list of labels we will annotate with and return the label menu GUI. Additionally, we will create and connect all of the required callbacks to make the GUI interactive.
 
 ```python
@@ -208,7 +211,7 @@ def create_label_menu(points_layer, labels):
         a napari points layer
     labels : List[str]
         list of the labels for each keypoint to be annotated (e.g., the body parts to be labeled).
-        
+
     Returns:
     --------
     label_menu : QComboBox
@@ -251,9 +254,9 @@ def label_changed(result):
     current_properties = points_layer.current_properties
     current_properties['label'] = np.asarray([selected_label])
     points_layer.current_properties = current_properties
-    
+
 label_menu.label_changed.connect(label_changed)
-``` 
+```
 
 Finally, we add the GUI created by magicgui to the napari viewer dock.
 
@@ -264,6 +267,7 @@ viewer.window.add_dock_widget(label_menu)
 ```
 
 ## Keybindings for switching labels
+
 For convenience, we can also define functions to increment and decrement the currently selected label and bind them to key presses using the napari keybindings framework.
 
 First, we define a function to increment to the next label and decorate it with the viewer key binding decorator. The decorator requires that we pass the key to bind the function to as a string and the decorated function should take an event as an input argument. In this case, we are binding `next_label()` to the `.` key.
@@ -272,17 +276,17 @@ First, we define a function to increment to the next label and decorate it with 
 @viewer.bind_key('.')
 def next_label(event=None):
     """Keybinding to advance to the next label with wraparound"""
-    
+
     # get the currently selected label
     current_properties = points_layer.current_properties
     current_label = current_properties['label'][0]
-    
+
     # determine the index of that label in the labels list
     ind = list(labels).index(current_label)
-    
+
     # increment the label with wraparound 
     new_ind = (ind + 1) % len(labels)
-    
+
     # get the new label and assign it
     new_label = labels[new_ind]
     current_properties['label'] = np.array([new_label])
@@ -306,6 +310,7 @@ def prev_label(event):
 ```
 
 ## Mousebinding to iterate through labels
+
 Similar to keybindings, we can also bind functions to mouse events such as clicking or dragging. Here, we create a function that will increment the label after a point is added (i.e., the mouse is clicked in the viewer canvas when in the point adding mode). This is convenient for quickly adding all labels to a frame, as one can simply click each feature in order without having to manually swap labels. To achieve this, we first check if the points layer is the the adding mode (`layer.mode == 'add'`). If so, we then reuse the next_label() function we defined above in the keybindings to increment the label. Finally, 
 
 ```python
@@ -328,7 +333,9 @@ points_layer.mouse_drag_callbacks.append(next_on_click)
 ```
 
 ## Using the GUI
+
 ### Launching the GUI
+
 Now that you've put it all together, you should be ready to test! You can call the function as shown below.
 
 ```python
@@ -339,6 +346,7 @@ point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'], output_path=output)
 ```
 
 ### Saving the annotations
+
 Once we are happy with the annotations, we can save them to a CSV file using the builing CSV writer for the points layer. To do so, first, select the "Points" layer in the layer list and then click "Save Selected layer(s)"  in the "File" menu or press control+S (cmd+S on Mac OS)  to bring up the file save dialog. From here you can enter the file path and save the annotation coordinates as a CSV.
 
 ![image]({{ '/assets/tutorials/points_save_dialog.png' | relative_url }})

--- a/applications/annotate_points.md
+++ b/applications/annotate_points.md
@@ -1,6 +1,8 @@
 # annotating videos with napari
 
-In this tutorial, we will use napari (requires version 0.3.2 or greater) to make a simple GUI application for annotating points in videos. This GUI could be useful for making annotations required to train algorithms for markless tracking of animals (e.g., [DeepLabCut](http://www.mousemotorlab.org/deeplabcut)). In this tutorial, we will cover creating and interacting with a Points layer with properties (i.e., labels for the points), connecting custom UI elements to events, and creating custom keybindings.
+In this tutorial, we will use napari (requires version 0.3.2 or greater) to make a simple GUI application for annotating points in videos.
+This GUI could be useful for making annotations required to train algorithms for markless tracking of animals (e.g., [DeepLabCut](http://www.mousemotorlab.org/deeplabcut)).
+In this tutorial, we will cover creating and interacting with a Points layer with properties (i.e., labels for the points), connecting custom UI elements to events, and creating custom keybindings.
 
 At the end of this tutorial, we will have created a GUI for annotating points in videos that we can simply call by:
 
@@ -14,7 +16,8 @@ The resulting viewer looks like this (images from [Mathis et al., 2018](https://
 
 ![image]({{ '/assets/tutorials/point_annotator_demo.gif' | relative_url }})
 
-You can explore the project in [this repository](https://github.com/kevinyamauchi/PointAnnotator) or check out the main function below. We will walk through the code in the following sections.
+You can explore the project in [this repository](https://github.com/kevinyamauchi/PointAnnotator) or check out the main function below.
+We will walk through the code in the following sections.
 
 ```python
 def create_label_menu(points_layer, labels):
@@ -121,7 +124,9 @@ def point_annotator(
 
 ## point_annotator()
 
-We will create the GUI within a function called `point_annotator()`. Wrapping the GUI creation in the function allows us to integrate it into other functions (e.g., a command line interface) and applications. See below for the function definition.
+We will create the GUI within a function called `point_annotator()`.
+Wrapping the GUI creation in the function allows us to integrate it into other functions (e.g., a command line interface) and applications.
+See below for the function definition.
 
 ```python
 def point_annotator(
@@ -142,13 +147,17 @@ def point_annotator(
 
 ## Loading the video
 
-First, we load the movie to be annotated. Since behavior movies can be quite long, we will use a lazy loading strategy (i.e., we will only load the frames as they are used). Using [`dask-image`](https://github.com/dask/dask-image), we can construct an object that we can pass to napari for lazy loading in just one line. For more explanation on using dask to lazily load images in napari, see [this](https://napari.org/tutorials/applications/dask) tutorial.
+First, we load the movie to be annotated.
+Since behavior movies can be quite long, we will use a lazy loading strategy (i.e., we will only load the frames as they are used).
+Using [`dask-image`](https://github.com/dask/dask-image), we can construct an object that we can pass to napari for lazy loading in just one line.
+For more explanation on using dask to lazily load images in napari, see [this](https://napari.org/tutorials/applications/dask) tutorial.
 
 ```python
 stack = imread(im_path)
 ```
 
-We can then start the viewer Note that we use the `napari.gui_qt()` context manager to start and manage Qt event loop. All of the following GUI code should be within the `napari.gui_qt()` context manager.
+We can then start the viewer Note that we use the `napari.gui_qt()` context manager to start and manage Qt event loop.
+All of the following GUI code should be within the `napari.gui_qt()` context manager.
 
 ```python
 with napari.gui_qt():
@@ -157,9 +166,18 @@ with napari.gui_qt():
 
 ## Annotating with points
 
-We will annotate the features of interest using points in a napari Points layer. Each feature will be given a different label so that we can track them across frames. To achieve this, we will store the label in the `Points.properties` property in the 'label' key. We will instantiate the `Points` layer without any points. However, we will initialize `Points.properties` with the property values we will be using to annotate the images. To do so, we will define a properties dictionary with a key named `label` and values `labels`. The key, 'label', is the name of the property we are storing which feature of interest each point corresponds with. The values, 'labels', is the list of the names of the features we will be annotating (defined above in the "point_annotator()" section). 
+We will annotate the features of interest using points in a napari Points layer.
+Each feature will be given a different label so that we can track them across frames.
+To achieve this, we will store the label in the `Points.properties` property in the 'label' key.
+We will instantiate the `Points` layer without any points.
+However, we will initialize `Points.properties` with the property values we will be using to annotate the images.
+To do so, we will define a properties dictionary with a key named `label` and values `labels`.
+The key, 'label', is the name of the property we are storing which feature of interest each point corresponds with.
+The values, 'labels', is the list of the names of the features we will be annotating (defined above in the "point_annotator()" section).
 
-We add the points layer to the viewer using the `viewer.add_points()` method. As discussed above, we will be storing which feature of interest each points corresponds to via the `label` property we defined in the `properties` dictionary. To visualize the feature each points represent, we set the edge color as a color cycle mapped to the `label` property (`edge_color='label'`). 
+We add the points layer to the viewer using the `viewer.add_points()` method.
+As discussed above, we will be storing which feature of interest each points corresponds to via the `label` property we defined in the `properties` dictionary.
+To visualize the feature each points represent, we set the edge color as a color cycle mapped to the `label` property (`edge_color='label'`).
 
 ```python
 properties = {'label': labels}
@@ -174,7 +192,10 @@ points_layer = viewer.add_points(
 )
 ```
 
-Note that we set the `edge_color_cycle` to `COLOR_CYCLE`. You can define your own color cycle as a list of colors. The colors can be defined as hex strings, standard color names or RGBA arrays. For example, the [category10 color pallete](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10) would be:
+Note that we set the `edge_color_cycle` to `COLOR_CYCLE`.
+You can define your own color cycle as a list of colors.
+The colors can be defined as hex strings, standard color names or RGBA arrays.
+For example, the [category10 color pallete](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10) would be:
 
 ```python
 COLOR_CYCLE = [
@@ -199,7 +220,9 @@ Finally, we set the edge color to a color cycle:
 
 ## Adding a GUI for selecting points
 
-First, we will define a function outside of the `napari.gui_qt()` context to create a GUI for select the labels for points. The function `create_label_menu()` will take the points layer we created and the list of labels we will annotate with and return the label menu GUI. Additionally, we will create and connect all of the required callbacks to make the GUI interactive.
+First, we will define a function outside of the `napari.gui_qt()` context to create a GUI for select the labels for points.
+The function `create_label_menu()` will take the points layer we created and the list of labels we will annotate with and return the label menu GUI.
+Additionally, we will create and connect all of the required callbacks to make the GUI interactive.
 
 ```python
 def create_label_menu(points_layer, labels):
@@ -219,7 +242,9 @@ def create_label_menu(points_layer, labels):
     """
 ```
 
-Within `create_label_menu()`, we will use magicgui to add a dropdown menu for selecting which the label for the point we are about to add or the point we have selected. [magicgui](https://github.com/napari/magicgui) is a library from the napari team for building GUIs from functions and works by applying function decorators. To make the a dropdown menu populated with the valid point labels, we simply define the function with the label as an input argument and then decorate it with the `magicgui()` decorator, passing the labels choice as `label={'choices': labels}` (recall that labels was passed to `point_annotator() as a list of the allowable labels).
+Within `create_label_menu()`, we will use magicgui to add a dropdown menu for selecting which the label for the point we are about to add or the point we have selected.
+[magicgui](https://github.com/napari/magicgui) is a library from the napari team for building GUIs from functions and works by applying function decorators.
+To make the a dropdown menu populated with the valid point labels, we simply define the function with the label as an input argument and then decorate it with the `magicgui()` decorator, passing the labels choice as `label={'choices': labels}` (recall that labels was passed to `point_annotator() as a list of the allowable labels).
 
 ```python
 @magicgui(label={'choices': labels})
@@ -227,7 +252,8 @@ def label_selection(label):
     return label
 ```
 
-To create the GUI, we call the label_selection. Gui() method.
+To create the GUI, we call the label_selection.
+Gui() method.
 
 ```python
 label_menu = label_selection.Gui()
@@ -235,7 +261,10 @@ label_menu = label_selection.Gui()
 
 We then need to connect the dropdown menu (`label_menu`) to the points layer to ensure the menu selection is always synchronized to the `Points` layer model.
 
-First, we define a function to update the label dropdown menu GUI when the value of the selected point or next point to be added is changed. On the points layer, the property values of the next point to be added are stored in the `current_properties` property. The points layer has an event that gets emitted when the `current_properties` property is changed (`points_layer.events.current_properties`). We connect the function we created to the event so that `update_label_menu()` is called whenever `Points.current_property` is changed.
+First, we define a function to update the label dropdown menu GUI when the value of the selected point or next point to be added is changed.
+On the points layer, the property values of the next point to be added are stored in the `current_properties` property.
+The points layer has an event that gets emitted when the `current_properties` property is changed (`points_layer.events.current_properties`).
+We connect the function we created to the event so that `update_label_menu()` is called whenever `Points.current_property` is changed.
 
 ```python
 def update_label_menu(event):
@@ -245,7 +274,9 @@ def update_label_menu(event):
 points_layer.events.current_properties.connect(update_label_menu)
 ```
 
-Next, we define a function to update the points layer if the selection in the labels dropdown menu is changed. Similar to the points layer, the magicgui object has an event that gets emitted whenever the selected label is changed (`label_menu.label_changed`). To ensure the points layer is updated whenever the GUI selection is changed, we connect `label_changed()` to the `label_menu.label_changed` event.
+Next, we define a function to update the points layer if the selection in the labels dropdown menu is changed.
+Similar to the points layer, the magicgui object has an event that gets emitted whenever the selected label is changed (`label_menu.label_changed`).
+To ensure the points layer is updated whenever the GUI selection is changed, we connect `label_changed()` to the `label_menu.label_changed` event.
 
 ```python
 def label_changed(result):
@@ -270,7 +301,9 @@ viewer.window.add_dock_widget(label_menu)
 
 For convenience, we can also define functions to increment and decrement the currently selected label and bind them to key presses using the napari keybindings framework.
 
-First, we define a function to increment to the next label and decorate it with the viewer key binding decorator. The decorator requires that we pass the key to bind the function to as a string and the decorated function should take an event as an input argument. In this case, we are binding `next_label()` to the `.` key.
+First, we define a function to increment to the next label and decorate it with the viewer key binding decorator.
+The decorator requires that we pass the key to bind the function to as a string and the decorated function should take an event as an input argument.
+In this case, we are binding `next_label()` to the `.` key.
 
 ```python
 @viewer.bind_key('.')
@@ -284,7 +317,7 @@ def next_label(event=None):
     # determine the index of that label in the labels list
     ind = list(labels).index(current_label)
 
-    # increment the label with wraparound 
+    # increment the label with wraparound
     new_ind = (ind + 1) % len(labels)
 
     # get the new label and assign it
@@ -311,7 +344,12 @@ def prev_label(event):
 
 ## Mousebinding to iterate through labels
 
-Similar to keybindings, we can also bind functions to mouse events such as clicking or dragging. Here, we create a function that will increment the label after a point is added (i.e., the mouse is clicked in the viewer canvas when in the point adding mode). This is convenient for quickly adding all labels to a frame, as one can simply click each feature in order without having to manually swap labels. To achieve this, we first check if the points layer is the the adding mode (`layer.mode == 'add'`). If so, we then reuse the next_label() function we defined above in the keybindings to increment the label. Finally, 
+Similar to keybindings, we can also bind functions to mouse events such as clicking or dragging.
+Here, we create a function that will increment the label after a point is added (i.e., the mouse is clicked in the viewer canvas when in the point adding mode).
+This is convenient for quickly adding all labels to a frame, as one can simply click each feature in order without having to manually swap labels.
+To achieve this, we first check if the points layer is the the adding mode (`layer.mode == 'add'`).
+If so, we then reuse the next_label() function we defined above in the keybindings to increment the label.
+Finally,
 
 ```python
 def next_on_click(layer, event):
@@ -325,7 +363,9 @@ def next_on_click(layer, event):
         layer.selected_data = []
 ```
 
-After creating the function, we then add it to the `points_layer` mouse drag callbacks. In napari, clicking and dragging events are both handled under the `mouse_drag_callbacks`. For more details on how mouse event callbacks work see the examples [[1](https://github.com/napari/napari/blob/master/examples/custom_mouse_functions.py), [2](https://github.com/napari/napari/blob/master/examples/mouse_drag_callback.py)].
+After creating the function, we then add it to the `points_layer` mouse drag callbacks.
+In napari, clicking and dragging events are both handled under the `mouse_drag_callbacks`.
+For more details on how mouse event callbacks work see the examples [[1](https://github.com/napari/napari/blob/master/examples/custom_mouse_functions.py), [2](https://github.com/napari/napari/blob/master/examples/mouse_drag_callback.py)].
 
 ```python
 # bind the callback to the mouse drag event
@@ -347,11 +387,14 @@ point_annotator(im_path, labels=['ear_l', 'ear_r', 'tail'], output_path=output)
 
 ### Saving the annotations
 
-Once we are happy with the annotations, we can save them to a CSV file using the builing CSV writer for the points layer. To do so, first, select the "Points" layer in the layer list and then click "Save Selected layer(s)"  in the "File" menu or press control+S (cmd+S on Mac OS)  to bring up the file save dialog. From here you can enter the file path and save the annotation coordinates as a CSV.
+Once we are happy with the annotations, we can save them to a CSV file using the builing CSV writer for the points layer.
+To do so, first, select the "Points" layer in the layer list and then click "Save Selected layer(s)"  in the "File" menu or press control+S (cmd+S on Mac OS)  to bring up the file save dialog.
+From here you can enter the file path and save the annotation coordinates as a CSV.
 
 ![image]({{ '/assets/tutorials/points_save_dialog.png' | relative_url }})
 
-Alternatively, we can use the `points_layer.save()` method to save the coordinates from the points layer to a CSV file. We can enter the command either in the script (e.g., bind a save function to a hot key) or the napari terminal.
+Alternatively, we can use the `points_layer.save()` method to save the coordinates from the points layer to a CSV file.
+We can enter the command either in the script (e.g., bind a save function to a hot key) or the napari terminal.
 
 ```python
 points_layer.save('path/to/file.csv')

--- a/applications/annotate_points.md
+++ b/applications/annotate_points.md
@@ -175,9 +175,9 @@ To do so, we will define a properties dictionary with a key named `label` and va
 The key, 'label', is the name of the property we are storing which feature of interest each point corresponds with.
 The values, 'labels', is the list of the names of the features we will be annotating (defined above in the "point_annotator()" section).
 
-We add the points layer to the viewer using the `viewer.add_points()` method.
-As discussed above, we will be storing which feature of interest each points corresponds to via the `label` property we defined in the `properties` dictionary.
-To visualize the feature each points represent, we set the edge color as a color cycle mapped to the `label` property (`edge_color='label'`).
+We add the `Points` layer to the viewer using the `viewer.add_points()` method.
+As discussed above, we will be storing which feature of interest each point corresponds to via the `label` property we defined in the `properties` dictionary.
+To visualize the feature each point represents, we set the edge color as a color cycle mapped to the `label` property (`edge_color='label'`).
 
 ```python
 properties = {'label': labels}
@@ -195,7 +195,7 @@ points_layer = viewer.add_points(
 Note that we set the `edge_color_cycle` to `COLOR_CYCLE`.
 You can define your own color cycle as a list of colors.
 The colors can be defined as hex strings, standard color names or RGBA arrays.
-For example, the [category10 color pallete](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10) would be:
+For example, the [category10 color palette](https://github.com/d3/d3-3.x-api-reference/blob/master/Ordinal-Scales.md#category10) would be:
 
 ```python
 COLOR_CYCLE = [
@@ -222,7 +222,7 @@ Finally, we set the edge color to a color cycle:
 
 First, we will define a function outside of the `napari.gui_qt()` context to create a GUI for select the labels for points.
 The function `create_label_menu()` will take the points layer we created and the list of labels we will annotate with and return the label menu GUI.
-Additionally, we will create and connect all of the required callbacks to make the GUI interactive.
+Additionally, we will create and connect all the required callbacks to make the GUI interactive.
 
 ```python
 def create_label_menu(points_layer, labels):
@@ -344,7 +344,7 @@ def prev_label(event):
 
 ## Mousebinding to iterate through labels
 
-Similar to keybindings, we can also bind functions to mouse events such as clicking or dragging.
+Like keybindings, we can also bind functions to mouse events such as clicking or dragging.
 Here, we create a function that will increment the label after a point is added (i.e., the mouse is clicked in the viewer canvas when in the point adding mode).
 This is convenient for quickly adding all labels to a frame, as one can simply click each feature in order without having to manually swap labels.
 To achieve this, we first check if the points layer is the the adding mode (`layer.mode == 'add'`).
@@ -365,7 +365,8 @@ def next_on_click(layer, event):
 
 After creating the function, we then add it to the `points_layer` mouse drag callbacks.
 In napari, clicking and dragging events are both handled under the `mouse_drag_callbacks`.
-For more details on how mouse event callbacks work see the examples [[1](https://github.com/napari/napari/blob/master/examples/custom_mouse_functions.py), [2](https://github.com/napari/napari/blob/master/examples/mouse_drag_callback.py)].
+For more details on how mouse event callbacks work,
+see the examples [[1](https://github.com/napari/napari/blob/master/examples/custom_mouse_functions.py), [2](https://github.com/napari/napari/blob/master/examples/mouse_drag_callback.py)].
 
 ```python
 # bind the callback to the mouse drag event

--- a/applications/dask.md
+++ b/applications/dask.md
@@ -53,7 +53,6 @@ stack.shape  # (nfiles, nz, ny, nx)
 stack
 ```
 
-
 ![image]({{ '/assets/tutorials/dask_repr.png' | relative_url }})
 
 *No data has been read from disk yet!*

--- a/applications/dask.md
+++ b/applications/dask.md
@@ -3,7 +3,7 @@
 Often in microscopy, multidimensional data is acquired and written to disk in many small files,
 each of which contain a subset of one or more dimensions from the complete dataset.
 For example, in a 5-dimensional experiment
-(e.g. 3D z-stacks aquired for multiple channels at various moments over time),
+(e.g. 3D z-stacks acquired for multiple channels at various moments over time),
 each file on disk might be a 3D TIFF stack from a single channel at a single timepoint.
 Data may also be stored in some proprietary format.
 As the size of the dataset grows,
@@ -14,7 +14,7 @@ Chunked file formats exist (such as [hdf5](https://support.hdfgroup.org/HDF5/) a
 > **Note**: This tutorial is not meant to promote a folder of TIFFs as a "good way" to store large datasets on disk;
 > but it is undoubtedly a common scenario in microscopy.
 > Chunked formats such as `hdf5` or `zarr` are superior in many ways, 
-> but they do require the user to either duplicate their data,
+> but they do require the user to either duplicate their data
 > or go "all in" and delete the original data after conversion.
 > And while `napari` can easily handle something like a `zarr` store,
 > it can be a bit more limiting inasmuch as it requires programs that are capable of viewing it (i.e. you can't necessarily just drag it into Fiji ...)
@@ -103,7 +103,7 @@ import napari
 
 with napari.gui_qt():
     # specify contrast_limits and is_pyramid=False with big data
-    # to avoid unecessary computations
+    # to avoid unnecessary computations
     napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 ```
 
@@ -180,14 +180,14 @@ stack[0, 0].compute()  # incurs a single file read
 ## processing data with `dask.array.map_blocks`
 
 As previously mentioned,
-sometimes it is desireable to process data prior to viewing.
+sometimes it is desirable to process data prior to viewing.
 We'll take as an example
 a series of TIFF files acquired on a lattice-light-sheet microscope.
 A typical workflow might be to deskew, deconvolve, and perhaps crop
 or apply some channel registration prior to viewing.
 
 With `dask.array.map_blocks` we can apply any function that accepts a `numpy` array
-and returns a modified array to all of the images in our `dask.array`.
+and returns a modified array to all the images in our `dask.array`.
 It will be evaluated lazily, when requested (in this case, by `napari`);
 we do not have to wait for it to process the entire dataset.
 
@@ -247,7 +247,7 @@ with napari.gui_qt():
 
 Of course, the GUI isn't as responsive as it would be if you had processed the data up front
 and loaded the results into RAM and viewed them in `napari` (it's doing a lot of work after all!),
-but it's suprisingly usable,
+but it's surprisingly usable,
 and allows you to preview the result of a relatively complex processing pipeline *on-the-fly*,
 for arbitrary timepoints/channels, while storing *only* the raw data on disk.
 

--- a/applications/dask.md
+++ b/applications/dask.md
@@ -1,18 +1,49 @@
 # using dask and napari to process & view large datasets
 
-Often in microscopy, multidimensional data is acquired and written to disk in many small files, each of which contain a subset of one or more dimensions from the complete dataset.  For example, in a 5-dimensional experiment (e.g. 3D z-stacks aquired for multiple channels at various moments over time), each file on disk might be a 3D TIFF stack from a single channel at a single timepoint.  Data may also be stored in some proprietary format.  As the size of the dataset grows, viewing arbitrary slices (in time, channel, z) of these datasets can become cumbersome.
+Often in microscopy, multidimensional data is acquired and written to disk in many small files,
+each of which contain a subset of one or more dimensions from the complete dataset.
+For example, in a 5-dimensional experiment
+(e.g. 3D z-stacks aquired for multiple channels at various moments over time),
+each file on disk might be a 3D TIFF stack from a single channel at a single timepoint.
+Data may also be stored in some proprietary format.
+As the size of the dataset grows,
+viewing arbitrary slices (in time, channel, z) of these datasets can become cumbersome.
 
 Chunked file formats exist (such as [hdf5](https://support.hdfgroup.org/HDF5/) and [zarr](https://zarr.readthedocs.io/en/stable/)) that store data in a way that makes it easier to retrieve arbitrary subsets of the dataset, but they require either data duplication, or "committing" to a new file standard.
 
-> **Note**: This tutorial is not meant to promote a folder of TIFFs as a "good way" to store large datasets on disk; but it is undoubtedly a common scenario in microscopy.  Chunked formats such as `hdf5` or `zarr` are superior in many ways, but they do require the user to either duplicate their data, or go "all in" and delete the original data after conversion.  And while `napari` can easily handle something like a `zarr` store, it can be a bit more limiting inasmuch as it requires programs that are capable of viewing it (i.e. you can't necessarily just drag it into Fiji ...)
+> **Note**: This tutorial is not meant to promote a folder of TIFFs as a "good way" to store large datasets on disk;
+> but it is undoubtedly a common scenario in microscopy.
+> Chunked formats such as `hdf5` or `zarr` are superior in many ways, 
+> but they do require the user to either duplicate their data,
+> or go "all in" and delete the original data after conversion.
+> And while `napari` can easily handle something like a `zarr` store,
+> it can be a bit more limiting inasmuch as it requires programs that are capable of viewing it (i.e. you can't necessarily just drag it into Fiji ...)
 
-The first part of this tutorial demonstrates how to use [`Dask`](https://docs.dask.org/en/latest/) and [`dask.delayed`](https://docs.dask.org/en/latest/delayed.html) (or [`dask_image`](https://github.com/dask/dask-image)) to feed `napari` image data "[lazily](https://en.wikipedia.org/wiki/Lazy_evaluation)": that is, the specific image file corresponding to the requested timepoint/channel is only read from disk at the moment it is required (based on the current position of the dimension sliders in `napari`).  Additionally, we will see that *any* function that takes a filepath and returns a `numpy` array can be used to lazily read image data.  This can be useful if you have a proprietary format that is not immediately recognized by `napari` (but for which you have at least some way of reading into a `numpy` array)
+The first part of this tutorial demonstrates how to use [`Dask`](https://docs.dask.org/en/latest/)
+and [`dask.delayed`](https://docs.dask.org/en/latest/delayed.html)
+(or [`dask_image`](https://github.com/dask/dask-image)) to feed `napari` image data "[lazily](https://en.wikipedia.org/wiki/Lazy_evaluation)":
+that is, the specific image file corresponding to the requested timepoint/channel
+is only read from disk at the moment it is required
+(based on the current position of the dimension sliders in `napari`).
+Additionally, we will see that *any* function that takes a filepath
+and returns a `numpy` array can be used to lazily read image data.
+This can be useful if you have a proprietary format that is not immediately recognized by `napari`
+(but for which you have at least some way of reading into a `numpy` array)
 
-In some cases, data must be further processed prior to viewing, such as a deskewing step for images acquired on a stage-scanning light sheet microscope.  Or perhaps you'd like to apply some basic image corrections or ratiometry prior to viewing.  The second part of this tutorial demonstrates the use of the [`dask.array.map_blocks`](https://docs.dask.org/en/latest/array-api.html#dask.array.map_blocks) function to describe an arbitrary sequence of functions in a declarative manner that will be performed *on demand* as you explore the data (i.e. move the sliders) in `napari`.
+In some cases, data must be further processed prior to viewing,
+such as a deskewing step for images acquired on a stage-scanning light sheet microscope.
+Or perhaps you'd like to apply some basic image corrections or ratiometry prior to viewing.
+The second part of this tutorial demonstrates the use of the [`dask.array.map_blocks`](https://docs.dask.org/en/latest/array-api.html#dask.array.map_blocks) function
+to describe an arbitrary sequence of functions in a declarative manner
+that will be performed *on demand* as you explore the data (i.e. move the sliders) in `napari`.
 
 ## using dask.delayed to load images
 
-If you have a function that can take a filename and return a `numpy` array, such as `skimage.io.imread`, you can create a "lazy" version of that function by calling `dask.delayed` on the function itself.  This *new* function, when handed a filename, will not actually read the file until explicitly asked with the `compute()` method:
+If you have a function that can take a filename and return a `numpy` array,
+such as `skimage.io.imread`,
+you can create a "lazy" version of that function by calling `dask.delayed` on the function itself.
+This *new* function, when handed a filename,
+will not actually read the file until explicitly asked with the `compute()` method:
 
 ```python
 from skimage.io import imread
@@ -23,9 +54,14 @@ reader = lazy_imread('/path/to/file.tif')  # doesn't actually read the file
 array = reader.compute()  # *now* it reads.
 ```
 
-(If you have an unusual image format, but you *do* have a python function that returns a `numpy` array, simply substitute it for `skimage.io.imread` in the example above).  
+(If you have an unusual image format,
+but you *do* have a python function that returns a `numpy` array,
+simply substitute it for `skimage.io.imread` in the example above).
 
-We can create a [Dask array](https://docs.dask.org/en/latest/array.html) of delayed file-readers for *all* of the files in our multidimensional experiment using the `dask.array.from_delayed` function and a [`glob`](https://docs.python.org/3/library/glob.html) filename pattern (*this example assumes that all files are of the same `shape` and `dtype`!*):
+We can create a [Dask array](https://docs.dask.org/en/latest/array.html) of delayed file-readers
+for *all* of the files in our multidimensional experiment using the `dask.array.from_delayed` function
+and a [`glob`](https://docs.python.org/3/library/glob.html) filename pattern
+(*this example assumes that all files are of the same `shape` and `dtype`!*):
 
 ```python
 from skimage.io import imread
@@ -57,7 +93,10 @@ stack
 
 *No data has been read from disk yet!*
 
-`napari` is capable of consuming Dask arrays, so you can simply call `napari.view_image` on this `stack` and behind the scenes, Dask will take care of reading the data from disk and handing a `numpy` array to `napari` each time a new timepoint or channel is requested.
+`napari` is capable of consuming Dask arrays,
+so you can simply call `napari.view_image` on this `stack` and behind the scenes,
+Dask will take care of reading the data from disk
+and handing a `numpy` array to `napari` each time a new timepoint or channel is requested.
 
 ```python
 import napari
@@ -68,11 +107,17 @@ with napari.gui_qt():
     napari.view_image(stack, contrast_limits=[0,2000], multiscale=False)
 ```
 
-*Note: providing the* `contrast_limits` *and* `multiscale` *arguments prevents* `napari` *from trying to calculate the data min/max, which can take an extremely long time with big data.  See [napari issue #736](https://github.com/napari/napari/issues/736) for further discussion.*
+*Note: providing the* `contrast_limits` *and* `multiscale` *arguments prevents* `napari` *from trying to calculate the data min/max, which can take an extremely long time with big data.
+See [napari issue #736](https://github.com/napari/napari/issues/736) for further discussion.*
 
 ## make your life easier with `dask-image`
 
-This pattern for creating a `dask.array` from image data has been previously described in an [excellent blog post](https://blog.dask.org/2019/06/20/load-image-data) by John Kirkham.  It is a common-enough pattern that John created a useful library ([`dask-image`](https://github.com/dask/dask-image)) that does all this for you, provided your image format can be read by the [`pims`](https://github.com/soft-matter/pims) (Python Image Sequence) reader (if not, see note above about providing your own reader function with `dask.delayed`).
+This pattern for creating a `dask.array` from image data
+has been previously described in an [excellent blog post](https://blog.dask.org/2019/06/20/load-image-data) by John Kirkham.
+It is a common-enough pattern that John created a useful library ([`dask-image`](https://github.com/dask/dask-image))
+that does all this for you,
+provided your image format can be read by the [`pims`](https://github.com/soft-matter/pims) (Python Image Sequence) reader
+(if not, see note above about providing your own reader function with `dask.delayed`).
 
 Using `dask-image`, *all* of the above code can be simplified to 5 lines:
 
@@ -90,9 +135,9 @@ with napari.gui_qt():
 
 ### **side note regarding higher-dimensional datasets**
 
-In the above example, it would be quite common to have a 5+ dimensional dataset (e.g. different
-timepoints *and* channels represented among the 3D TIFF files in a folder).  A standard approach to
-deal with that sort of thing in `numpy` would be to `reshape` the array after instantiation.
+In the above example, it would be quite common to have a 5+ dimensional dataset
+(e.g. different timepoints *and* channels represented among the 3D TIFF files in a folder).
+A standard approach to deal with that sort of thing in `numpy` would be to `reshape` the array after instantiation.
 With Dask, reshaping arrays can *sometimes* lead to unexpected read events if you're not careful.
 
 For example:
@@ -109,7 +154,8 @@ stack = stack.reshape(2, 600, 64, 256, 280)
 stack[0, 0].compute()  # incurs 600 read events!
 ```
 
-We will update this post as best-practices emerge, but one possible solution to this is to avoid reshaping
+We will update this post as best-practices emerge,
+but one possible solution to this is to avoid reshaping
 Dask arrays altogether, by constructing multiple Dask arrays using `dask-image`, and then using
 `da.stack` to combine them:
 
@@ -133,11 +179,21 @@ stack[0, 0].compute()  # incurs a single file read
 
 ## processing data with `dask.array.map_blocks`
 
-As previously mentioned, sometimes it is desireable to process data prior to viewing. We'll take as an example a series of TIFF files acquired on a lattice-light-sheet microscope.  A typical workflow might be to deskew, deconvolve, and perhaps crop or apply some channel registration prior to viewing.
+As previously mentioned,
+sometimes it is desireable to process data prior to viewing.
+We'll take as an example
+a series of TIFF files acquired on a lattice-light-sheet microscope.
+A typical workflow might be to deskew, deconvolve, and perhaps crop
+or apply some channel registration prior to viewing.
 
-With `dask.array.map_blocks` we can apply any function that accepts a `numpy` array and returns a modified array to all of the images in our `dask.array`.  It will be evaluated lazily, when requested (in this case, by `napari`); we do not have to wait for it to process the entire dataset.
+With `dask.array.map_blocks` we can apply any function that accepts a `numpy` array
+and returns a modified array to all of the images in our `dask.array`.
+It will be evaluated lazily, when requested (in this case, by `napari`);
+we do not have to wait for it to process the entire dataset.
 
-Here is an example of a script that will take a folder of raw tiff files, and lazily read, deskew, deconvolve, crop, and display them, *on demand* as you move the `napari` dimensions sliders around.
+Here is an example of a script that will take a folder of raw tiff files,
+and lazily read, deskew, deconvolve, crop,
+and display them, *on demand* as you move the `napari` dimensions sliders around.
 
 ```python
 import napari
@@ -189,11 +245,18 @@ with napari.gui_qt():
 
 ```
 
-Of course, the GUI isn't as responsive as it would be if you had processed the data up front and loaded the results into RAM and viewed them in `napari` (it's doing a lot of work after all!), but it's suprisingly usable, and allows you to preview the result of a relatively complex processing pipeline *on-the-fly*, for arbitrary timepoints/channels, while storing *only* the raw data on disk.
+Of course, the GUI isn't as responsive as it would be if you had processed the data up front
+and loaded the results into RAM and viewed them in `napari` (it's doing a lot of work after all!),
+but it's suprisingly usable,
+and allows you to preview the result of a relatively complex processing pipeline *on-the-fly*,
+for arbitrary timepoints/channels, while storing *only* the raw data on disk.
 
 {% include image.html url="/assets/tutorials/dask2.gif" description="same dataset, demonstrating on-the-fly read → deskew → deconvolve → crop" %}
 
-This workflow is very much patterned after [another great post by John Kirkham, Matthew Rocklin, and Matthew McCormick](https://blog.dask.org/2019/08/09/image-itk) that describes a similar image processing pipeline using [ITK](https://itk.org/).  `napari` simply sits at the end of this lazy processing chain, ready to show you the result on demand!
+This workflow is very much patterned after [another great post by John Kirkham, Matthew Rocklin, and Matthew McCormick](https://blog.dask.org/2019/08/09/image-itk)
+that describes a similar image processing pipeline using [ITK](https://itk.org/).
+`napari` simply sits at the end of this lazy processing chain,
+ready to show you the result on demand!
 
 ## Further Reading
 

--- a/fundamentals/getting_started.md
+++ b/fundamentals/getting_started.md
@@ -2,9 +2,11 @@
 
 Welcome to the getting started with **napari** tutorial!
 
-This tutorial assumes you have already installed napari. For help with installation see our [installation tutorial](./installation).
+This tutorial assumes you have already installed napari.
+For help with installation see our [installation tutorial](./installation).
 
-This tutorial will teach you all the different ways to launch napari. At the end of the tutorial you should be able to launch napari and see the viewer your favourite way.
+This tutorial will teach you all the different ways to launch napari.
+At the end of the tutorial you should be able to launch napari and see the viewer your favourite way.
 
 ## launching napari
 
@@ -15,7 +17,8 @@ There are four ways to launch the **napari** viewer:
 - IPython console
 - jupyter notebook
 
-All four of these methods will launch the same napari viewer, but depending on your use-case different ones may be preferable.
+All four of these methods will launch the same napari viewer,
+but depending on your use-case different ones may be preferable.
 
 ### command line usage
 
@@ -29,7 +32,12 @@ This command will launch an empty viewer:
 
 ![image]({{ '/assets/tutorials/launch_cli_empty.png' | relative_url }})
 
-Once you have the viewer open you can add images through the `File/Open` dropdown menu or by dragging and dropping images directly on the viewer. We currently only support files that can be read with [`skimage.io.imread`](https://scikit-image.org/docs/dev/api/skimage.io.html#skimage.io.imread), such as `tif`, `png`, and `jpg`. We plan on adding support for more exotic file types shortly - see [issue #379](https://github.com/napari/napari/issues/379) for discussion. You can also create new empty `points`, `shapes`, and `labels` layers using the new layer buttons in the bottom right of the viewer.
+Once you have the viewer open you can add images through the `File/Open` dropdown menu
+or by dragging and dropping images directly on the viewer.
+We currently only support files that can be read with [`skimage.io.imread`](https://scikit-image.org/docs/dev/api/skimage.io.html#skimage.io.imread),
+such as `tif`, `png`, and `jpg`.
+We plan on adding support for more exotic file types shortly - see [issue #379](https://github.com/napari/napari/issues/379) for discussion.
+You can also create new empty `points`, `shapes`, and `labels` layers using the new layer buttons in the bottom right of the viewer.
 
 You can also directly load an image into the viewer from the command line by passing the path to the image as an argument as follows
 
@@ -41,11 +49,15 @@ If the image is `RGB` or `RGBA` use the `-r` or `--rgb` flag.
 
 ![image]({{ '/assets/tutorials/launch_cli_image.png' | relative_url }})
 
-Launching napari directly from the command line is the simplest and fastest way to open the viewer, but it doesn't allow you to preprocess your images before opening them. It is also currently not possible to save images or other layer types directly from the viewer, but we'll be adding support for this functionality soon as discussed in [#379](https://github.com/napari/napari/issues/379).
+Launching napari directly from the command line is the simplest and fastest way to open the viewer,
+but it doesn't allow you to preprocess your images before opening them.
+It is also currently not possible to save images or other layer types directly from the viewer,
+but we'll be adding support for this functionality soon as discussed in [#379](https://github.com/napari/napari/issues/379).
 
 ### python script usage
 
-To launch napari from a python script, inside your script you should import `napari`, create a Qt GUI context, and then create the `Viewer` by adding some data.
+To launch napari from a python script, inside your script you should import `napari`,
+create a Qt GUI context, and then create the `Viewer` by adding some data.
 
 For example to add an image and some points inside your script you should include:
 
@@ -71,11 +83,13 @@ See the scripts inside the [`examples`](https://github.com/napari/napari/tree/ma
 
 ![image]({{ '/assets/tutorials/launch_script.png' | relative_url }})
 
-An advantage of launching napari from a python script is that you can preprocess your images and add multiple layers before displaying the viewer.
+An advantage of launching napari from a python script
+is that you can preprocess your images and add multiple layers before displaying the viewer.
 
 ### IPython console usage
 
-To launch napari from an IPython console, first instantiate a Qt GUI and then import `napari` and create a `Viewer` object.
+To launch napari from an IPython console,
+first instantiate a Qt GUI and then import `napari` and create a `Viewer` object.
 
 It is best to launch the viewer with the GUI already set to be Qt by
 
@@ -94,24 +108,38 @@ from skimage.data import astronaut
 viewer = napari.view_image(astronaut(), rgb=True)
 ```
 
-If you did not launch IPython with the GUI already then you can set it from within IPython using `%gui qt`, but be warned that the Qt GUI can take a few seconds to be created and if you create the `Viewer` before it is finished, the kernel will die and the viewer will not launch.
+If you did not launch IPython with the GUI already then you can set it from within IPython using `%gui qt`,
+but be warned that the Qt GUI can take a few seconds to be created and if you create the `Viewer` before it is finished,
+the kernel will die and the viewer will not launch.
 
 ![image]({{ '/assets/tutorials/launch_ipython.png' | relative_url }})
 
-An advantage of launching napari from an IPython console is that the you can continue to programmatically interact with the viewer from the IPython console, including bidirectional communication, where code run in the console will update the current viewer and where data changed in the GUI will be accessible in the console.
+An advantage of launching napari from an IPython console
+is that the you can continue to programmatically interact with the viewer from the IPython console,
+including bidirectional communication, where code run in the console will update the current viewer
+and where data changed in the GUI will be accessible in the console.
 
 ### jupyter notebook usage
 
-You can also launch napari from a jupyter notebook, such as [`examples/notebook.ipynb`](https://github.com/napari/napari/tree/master/examples/notebook.ipynb)
+You can also launch napari from a jupyter notebook,
+such as [`examples/notebook.ipynb`](https://github.com/napari/napari/tree/master/examples/notebook.ipynb)
 
 ![image]({{ '/assets/tutorials/launch_jupyter.png' | relative_url }})
 
-As in the case of the IPython console though you must wait for the Qt GUI to instantiate following the `%gui qt` magic command. Instantiating the Qt GUI can take a few seconds and if you create the `Viewer` before it is finished, the kernel will die and the viewer will not launch. For this reason the `%gui qt` magic command should always be run in a separate cell from creating the viewer.
+As in the case of the IPython console though you must wait for the Qt GUI to instantiate following the `%gui qt` magic command.
+Instantiating the Qt GUI can take a few seconds and if you create the `Viewer` before it is finished,
+the kernel will die and the viewer will not launch.
+For this reason the `%gui qt` magic command should always be run in a separate cell from creating the viewer.
 
-Similar to launching from the IPython console, an advantage of launching napari from a jupyter notebook is that you can continue to programmatically interact with the viewer from jupyter notebook, including bidirectional communication, where code run in the notebook will update the current viewer and where data changed in the GUI will be accessible in the notebook.
+Similar to launching from the IPython console,
+an advantage of launching napari from a jupyter notebook
+is that you can continue to programmatically interact with the viewer from jupyter notebook,
+including bidirectional communication, where code run in the notebook will update the current viewer
+and where data changed in the GUI will be accessible in the notebook.
 
 ## next steps
 
-To learn more about how to use the napari viewer the different types of napari layers checkout the [viewer tutorial](./viewer) and more of our tutorials listed below.
+To learn more about how to use the napari viewer the different types of napari layers
+checkout the [viewer tutorial](./viewer) and more of our tutorials listed below.
 
 {% include footer.md %}

--- a/fundamentals/getting_started.md
+++ b/fundamentals/getting_started.md
@@ -6,7 +6,7 @@ This tutorial assumes you have already installed napari.
 For help with installation see our [installation tutorial](./installation).
 
 This tutorial will teach you all the different ways to launch napari.
-At the end of the tutorial you should be able to launch napari and see the viewer your favourite way.
+At the end of the tutorial you should be able to launch napari and see the viewer your favorite way.
 
 ## launching napari
 
@@ -17,7 +17,7 @@ There are four ways to launch the **napari** viewer:
 - IPython console
 - jupyter notebook
 
-All four of these methods will launch the same napari viewer,
+All four of these methods will launch the same napari viewer
 but depending on your use-case different ones may be preferable.
 
 ### command line usage
@@ -59,7 +59,7 @@ but we'll be adding support for this functionality soon as discussed in [#379](h
 To launch napari from a python script, inside your script you should import `napari`,
 create a Qt GUI context, and then create the `Viewer` by adding some data.
 
-For example to add an image and some points inside your script you should include:
+For example, to add an image and some points inside your script you should include:
 
 ```python
 import napari
@@ -110,7 +110,7 @@ viewer = napari.view_image(astronaut(), rgb=True)
 
 If you did not launch IPython with the GUI already then you can set it from within IPython using `%gui qt`,
 but be warned that the Qt GUI can take a few seconds to be created and if you create the `Viewer` before it is finished,
-the kernel will die and the viewer will not launch.
+the kernel will die, and the viewer will not launch.
 
 ![image]({{ '/assets/tutorials/launch_ipython.png' | relative_url }})
 
@@ -129,7 +129,7 @@ such as [`examples/notebook.ipynb`](https://github.com/napari/napari/tree/master
 As in the case of the IPython console though you must wait for the Qt GUI to instantiate following the `%gui qt` magic command.
 Instantiating the Qt GUI can take a few seconds and if you create the `Viewer` before it is finished,
 the kernel will die and the viewer will not launch.
-For this reason the `%gui qt` magic command should always be run in a separate cell from creating the viewer.
+For this reason, the `%gui qt` magic command should always be run in a separate cell from creating the viewer.
 
 Similar to launching from the IPython console,
 an advantage of launching napari from a jupyter notebook
@@ -139,7 +139,7 @@ and where data changed in the GUI will be accessible in the notebook.
 
 ## next steps
 
-To learn more about how to use the napari viewer the different types of napari layers
+To learn more about how to use the napari viewer with different types of napari layers
 checkout the [viewer tutorial](./viewer) and more of our tutorials listed below.
 
 {% include footer.md %}

--- a/fundamentals/getting_started.md
+++ b/fundamentals/getting_started.md
@@ -6,7 +6,6 @@ This tutorial assumes you have already installed napari. For help with installat
 
 This tutorial will teach you all the different ways to launch napari. At the end of the tutorial you should be able to launch napari and see the viewer your favourite way.
 
-
 ## launching napari
 
 There are four ways to launch the **napari** viewer:
@@ -16,12 +15,12 @@ There are four ways to launch the **napari** viewer:
 - IPython console
 - jupyter notebook
 
-
 All four of these methods will launch the same napari viewer, but depending on your use-case different ones may be preferable.
 
 ### command line usage
 
 To launch napari from the command line simply run
+
 ```sh
 napari
 ```
@@ -33,9 +32,11 @@ This command will launch an empty viewer:
 Once you have the viewer open you can add images through the `File/Open` dropdown menu or by dragging and dropping images directly on the viewer. We currently only support files that can be read with [`skimage.io.imread`](https://scikit-image.org/docs/dev/api/skimage.io.html#skimage.io.imread), such as `tif`, `png`, and `jpg`. We plan on adding support for more exotic file types shortly - see [issue #379](https://github.com/napari/napari/issues/379) for discussion. You can also create new empty `points`, `shapes`, and `labels` layers using the new layer buttons in the bottom right of the viewer.
 
 You can also directly load an image into the viewer from the command line by passing the path to the image as an argument as follows
+
 ```sh
 napari my_image.png
 ```
+
 If the image is `RGB` or `RGBA` use the `-r` or `--rgb` flag.
 
 ![image]({{ '/assets/tutorials/launch_cli_image.png' | relative_url }})
@@ -61,6 +62,7 @@ with napari.gui_qt():
 ```
 
 then run your script from the command line to launch the viewer with your data:
+
 ```sh
 python my_example_script.py
 ```
@@ -77,11 +79,12 @@ To launch napari from an IPython console, first instantiate a Qt GUI and then im
 
 It is best to launch the viewer with the GUI already set to be Qt by
 
-```
+```sh
 IPython --gui=qt
 ```
 
 Then inside IPython
+
 ```python
 # instantiate Qt GUI
 import napari

--- a/fundamentals/image.md
+++ b/fundamentals/image.md
@@ -78,26 +78,26 @@ a [zarr array](https://zarr.readthedocs.io/en/stable/api/core.html),
 or any other object that you can index into
 and when you call [`np.asarray`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html) on it you get back a numpy array.
 
-The great thing about napari support array-like objects is that you get to keep on using you favourite array libraries
+The great thing about napari support array-like objects is that you get to keep on using your favorite array libraries
 without worrying about any conversions as we'll handle all of that for you.
 
 napari will also wait until just before it displays data onto the screen to actually generate a numpy array from your data,
 and so if you're using a library like `dask` or `zarr` that supports lazy loading and lazy evaluation,
-we wont force you load or compute on data that you're not looking at.
-This enables napari to seemlessly browse enormous datasets that are loaded in the right way.
+we won't force you load or compute on data that you're not looking at.
+This enables napari to seamlessly browse enormous datasets that are loaded in the right way.
 For example, here we are browsing over 100GB of lattice lightsheet data stored in a zarr file:
 
 ![image]({{ '/assets/tutorials/LLSM.gif' | relative_url }})
 
 ## image pyramids
 
-For very large datasets napari supports image pyramids.
+For exceptionally large datasets napari supports image pyramids.
 An image pyramid is a list of arrays, where each array is downsampling of the previous array in the list,
 so that you end up with images of successively smaller and smaller shapes.
 A standard image pyramid might have a 2x downsampling at each level,
 but napari can support any type of pyramid as long as the shapes are getting smaller each time.
 
-Image pyramids for are very useful for incredibly large 2D images when viewed in 2D or incredibly large 3D images when viewed in 3D.
+Image pyramids are especially useful for incredibly large 2D images when viewed in 2D or incredibly large 3D images when viewed in 3D.
 For example this ~100k x 200k pixel pathology image consists of 10 pyramid levels
 and can be easily browsed as at each moment in time
 we only load the level of the pyramid and the part of the image that needs to be displayed:
@@ -105,16 +105,16 @@ we only load the level of the pyramid and the part of the image that needs to be
 ![image]({{ '/assets/tutorials/pathology.gif' | relative_url }})
 
 This example had precomputed image pyramids stored in a zarr file, which is best for performance.
-If however you don't have a precomputed pyramid but try and show a very large image
+If, however you don't have a precomputed pyramid but try and show a exceptionally large image
 napari will try and compute pyramids for you unless you tell it not too.
 
-You can use the `is_pyramid` keyword argument to specify if you data is an image pyramid or not.
-If you don't provide this value then will try and guess whether your data is or needs to be an image pyramid.
+You can use the `is_pyramid` keyword argument to specify if your data is an image pyramid or not.
+If you don't provide this value, then will try and guess whether your data is or needs to be an image pyramid.
 
 ## 3D rendering of images
 
 All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer,
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer,
 allowing you to browse volumetric timeseries data and other high dimensional data.
 See for example these cells undergoing mitosis in this volumetric timeseries:
 
@@ -177,7 +177,7 @@ It is also possible to create your own colormaps using vispy's `vispy.color.Colo
 see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap).
 Briefly, you can pass `Colormap` a list of length 3 or length 4 lists,
 corresponding to the `rgb` or `rgba` values at different points along the colormap.
-For example to make a diverging colormap the goes from red to blue through black
+For example, to make a diverging colormap that goes from red to blue through black,
 and color a random array you can do the following:
 
 ```python
@@ -198,7 +198,7 @@ with napari.gui_qt():
 Note in this example how we passed the colormap keyword argument as a tuple containing both a name for our new custom colormap and the colormap itself.
 If we had only passed the colormap it would have been given a default name.
 
-The named colormap now appears in the dropdown menu along side a little thumbnail of the full range of the colormap.
+The named colormap now appears in the dropdown menu alongside a little thumbnail of the full range of the colormap.
 
 ## adjusting contrast limits
 
@@ -209,14 +209,14 @@ All values of image data smaller than this value will also get mapped to this co
 The larger contrast limit corresponds to the value of the image data that will get mapped to the color defined by 1 in the colormap.
 All values of image data larger than this value will also get mapped to this color.
 
-For example you are looking at an image that has values between 0 and 100 with a standard `gray` colormap,
+For example, you are looking at an image that has values between 0 and 100 with a standard `gray` colormap,
 and you set the contrast limits to `(20, 75)`.
 Then all the pixels with values less than 20 will get mapped to black, the color corresponding to 0 in the colormap,
 and all pixels with values greater than 75 will get mapped to white, the color corresponding to 1 in the colormap.
 All other pixel values between 20 and 75 will get linearly mapped onto the range of colors between black and white.
 
 In napari you can set the contrast limits when creating an `Image` layer
-or on an existing layer using the `contrast_limits` keyword argument or property respectively.
+or on an existing layer using the `contrast_limits` keyword argument or property, respectively.
 
 ```python
 viewer = napari.view_image(data.moon(), name='moon')
@@ -232,12 +232,12 @@ one that adjusts the larger value.
 
 As of right now adjusting the contras limits has no effect for `rgb` data.
 
-If no contrast limits are passed then napari will compute them.
+If no contrast limits are passed, then napari will compute them.
 If your data is small, then napari will just take the minimum and maximum values across your entire image.
-If your data is very large, this operation can be very time consuming
+If your data is exceptionally large, this operation can be very time consuming
 and so if you have passed an image pyramid then napari will just use the top level of that pyramid,
 or it will use the minimum and maximum values across the top, middle, and bottom slices of your image.
-In general if working with big images it is recommended you explicitly set the contrast limits if you can.
+In general, if working with big images it is recommended you explicitly set the contrast limits if you can.
 
 Currently if you pass contrast limits as a keyword argument to a layer
 then full extent of the contrast limits range slider will be set to those values.
@@ -250,22 +250,22 @@ This property is located inside the layer widget in the layers list and is repre
 ## layer opacity
 
 All our layers support an opacity slider and `opacity` property
-that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+that allow you to adjust the layer opacity between 0, fully invisible and 1, fully visible.
 
 ## blending layers
 
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
-This mode is very useful for many cell biology applications
+This mode is especially useful for many cell biology applications
 where you have multiple different components of a cell labeled in different colors.
 For example:
 
@@ -283,7 +283,7 @@ These modes have no effect when viewing 3D slices.
 
 ## layer rendering
 
-When viewing 3D slices we support a variety of rendering modes.
+When viewing 3D slices, we support a variety of rendering modes.
 The default mode `mip`, or maximum intensity projection,
 will combine voxels at different distances from the camera according to a maximum intensity projection
 to create the 2D image that is then displayed on the screen.
@@ -319,7 +319,7 @@ that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Image` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Image` layer,
 including how to create one and control its properties.
 To learn more about some of the other layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/image.md
+++ b/fundamentals/image.md
@@ -27,7 +27,8 @@ with napari.gui_qt():
 
 Both `view_image` and `add_image` have the following doc strings:
 
-```
+```python
+"""
 Parameters
 ----------
 image : np.ndarray
@@ -51,6 +52,7 @@ Returns
 -------
 layer : napari.layers.Image
     The newly-created image layer.
+"""
 ```
 
 ## image data and numpy-like arrays
@@ -62,7 +64,6 @@ The great thing about napari support array-like objects is that you get to keep 
 napari will also wait until just before it displays data onto the screen to actually generate a numpy array from your data, and so if you're using a library like `dask` or `zarr` that supports lazy loading and lazy evaluation, we wont force you load or compute on data that you're not looking at. This enables napari to seemlessly browse enormous datasets that are loaded in the right way. For example, here we are browsing over 100GB of lattice lightsheet data stored in a zarr file:
 
 ![image]({{ '/assets/tutorials/LLSM.gif' | relative_url }})
-
 
 ## image pyramids
 
@@ -82,19 +83,22 @@ All our layers can be rendered in both 2D and 3D mode, and one of our viewer but
 
 ![image]({{ '/assets/tutorials/mitosis.gif' | relative_url }})
 
-
 ## viewing rgb vs luminance (grayscale) images
 
 In the above example we explicitly set the `rgb` keyword to be `True` because we knew we were working with an `rgb` image.
+
 ```python
 viewer = napari.view_image(data.astronaut(), rgb=True)
 ```
+
 If we had left that keyword argument out napari would have successfully guessed that we were trying to show an `rgb` or `rgba` image because the final dimension was 3 or 4. If you have a luminance image where the last dimension is 3 or 4 you can set the `rgb` property to `False` so napari handles the image correctly.
 
 `rgb` data must either be `uint8`, corresponding to values between 0 and 255, or `float` and between 0 and 1. If the values are `float` and outside the 0 to 1 range they will be clipped.
 
 ## working with colormaps
+
 napari supports any colormap that is created with `vispy.color.Colormap`. We provide access to some standard colormaps that you can set using a string of their name. These include:
+
 - PiYG
 - blue
 - cyan
@@ -114,9 +118,11 @@ napari supports any colormap that is created with `vispy.color.Colormap`. We pro
 - viridis
 
 Passing any of these as follows
+
 ```python
 viewer = napari.view_image(data.moon(), colormap='red')
 ```
+
 will set the colormap of that image. You can also access the current colormap through the `layer.colormap` property which returns a tuple of the colormap name followed by the vispy colormap object. You can list all the available colormaps using `layer.colormaps`.
 
 It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object, see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap). Briefly, you can pass `Colormap` a list of length 3 or length 4 lists, corresponding to the `rgb` or `rgba` values at different points along the colormap. For example to make a diverging colormap the goes from red to blue through black and color a random array you can do the following:
@@ -141,6 +147,7 @@ Note in this example how we passed the colormap keyword argument as a tuple cont
 The named colormap now appears in the dropdown menu along side a little thumbnail of the full range of the colormap.
 
 ## adjusting contrast limits
+
 Each image layer gets mapped through its colormap according to values called contrast limits. The contrast limits are a 2-tuple where the second value is larger than the first. The smaller contrast limit corresponds to the value of the image data that will get mapped to the color defined by 0 in the colormap. All values of image data smaller than this value will also get mapped to this color. The larger contrast limit corresponds to the value of the image data that will get mapped to the color defined by 1 in the colormap. All values of image data larger than this value will also get mapped to this color.
 
 For example you are looking at an image that has values between 0 and 100 with a standard `gray` colormap, and you set the contrast limits to `(20, 75)` Then all the pixels with values less than 20 will get mapped to black, the color corresponding to 0 in the colormap, and all pixels with values greater than 75 will get mapped to white, the color corresponding to 1 in the colormap. All other pixel values between 20 and 75 will get linearly mapped onto the range of colors between black and white.

--- a/fundamentals/image.md
+++ b/fundamentals/image.md
@@ -2,14 +2,27 @@
 
 Welcome to the tutorial on the **napari** `Image` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders
+see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Image` layer, including the types of images that can be displayed, and how
-to set properties like the contrast, opacity, colormaps and blending mode. At the end of the tutorial you should understand how to add and manipulate a variety of different types of images both from the GUI and from the console.
+This tutorial will teach you about the **napari** `Image` layer,
+including the types of images that can be displayed,
+and how to set properties like the contrast, opacity, colormaps and blending mode.
+At the end of the tutorial you should understand how to add and manipulate a variety of different types of images both from the GUI and from the console.
 
 ## a simple example
 
-You can create a new viewer and add an image in one go using the `napari.view_image` method, or if you already have an existing viewer, you can add an image to it using `viewer.add_image`. The api of both methods is the same. In these examples we'll mainly use `view_image`.
+You can create a new viewer and add an image in one go using the `napari.view_image` method,
+or if you already have an existing viewer, you can add an image to it using `viewer.add_image`.
+The api of both methods is the same.
+In these examples we'll mainly use `view_image`.
 
 A simple example of viewing an image is as follows:
 
@@ -57,47 +70,79 @@ layer : napari.layers.Image
 
 ## image data and numpy-like arrays
 
-napari can take any numpy-like array as input for its image layer. A numpy-like array can just be a [numpy array](https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html), a [dask array](https://docs.dask.org/en/stable/array.html), an [xarray](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html), a [zarr array](https://zarr.readthedocs.io/en/stable/api/core.html), or any other object that you can index into and when you call [`np.asarray`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html) on it you get back a numpy array.
+napari can take any numpy-like array as input for its image layer.
+A numpy-like array can just be a [numpy array](https://docs.scipy.org/doc/numpy/reference/generated/numpy.array.html),
+a [dask array](https://docs.dask.org/en/stable/array.html),
+an [xarray](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html),
+a [zarr array](https://zarr.readthedocs.io/en/stable/api/core.html),
+or any other object that you can index into
+and when you call [`np.asarray`](https://docs.scipy.org/doc/numpy/reference/generated/numpy.asarray.html) on it you get back a numpy array.
 
-The great thing about napari support array-like objects is that you get to keep on using you favourite array libraries without worrying about any conversions as we'll handle all of that for you.
+The great thing about napari support array-like objects is that you get to keep on using you favourite array libraries
+without worrying about any conversions as we'll handle all of that for you.
 
-napari will also wait until just before it displays data onto the screen to actually generate a numpy array from your data, and so if you're using a library like `dask` or `zarr` that supports lazy loading and lazy evaluation, we wont force you load or compute on data that you're not looking at. This enables napari to seemlessly browse enormous datasets that are loaded in the right way. For example, here we are browsing over 100GB of lattice lightsheet data stored in a zarr file:
+napari will also wait until just before it displays data onto the screen to actually generate a numpy array from your data,
+and so if you're using a library like `dask` or `zarr` that supports lazy loading and lazy evaluation,
+we wont force you load or compute on data that you're not looking at.
+This enables napari to seemlessly browse enormous datasets that are loaded in the right way.
+For example, here we are browsing over 100GB of lattice lightsheet data stored in a zarr file:
 
 ![image]({{ '/assets/tutorials/LLSM.gif' | relative_url }})
 
 ## image pyramids
 
-For very large datasets napari supports image pyramids. An image pyramid is a list of arrays, where each array is downsampling of the previous array in the list, so that you end up with images of successively smaller and smaller shapes. A standard image pyramid might have a 2x downsampling at each level, but napari can support any type of pyramid as long as the shapes are getting smaller each time.
+For very large datasets napari supports image pyramids.
+An image pyramid is a list of arrays, where each array is downsampling of the previous array in the list,
+so that you end up with images of successively smaller and smaller shapes.
+A standard image pyramid might have a 2x downsampling at each level,
+but napari can support any type of pyramid as long as the shapes are getting smaller each time.
 
-Image pyramids for are very useful for incredibly large 2D images when viewed in 2D or incredibly large 3D images when viewed in 3D. For example this ~100k x 200k pixel pathology image consists of 10 pyramid levels and can be easily browsed as at each moment in time we only load the level of the pyramid and the part of the image that needs to be displayed:
+Image pyramids for are very useful for incredibly large 2D images when viewed in 2D or incredibly large 3D images when viewed in 3D.
+For example this ~100k x 200k pixel pathology image consists of 10 pyramid levels
+and can be easily browsed as at each moment in time
+we only load the level of the pyramid and the part of the image that needs to be displayed:
 
 ![image]({{ '/assets/tutorials/pathology.gif' | relative_url }})
 
-This example had precomputed image pyramids stored in a zarr file, which is best for performance. If however you don't have a precomputed pyramid but try and show a very large image napari will try and compute pyramids for you unless you tell it not too.
+This example had precomputed image pyramids stored in a zarr file, which is best for performance.
+If however you don't have a precomputed pyramid but try and show a very large image
+napari will try and compute pyramids for you unless you tell it not too.
 
-You can use the `is_pyramid` keyword argument to specify if you data is an image pyramid or not. If you don't provide this value then will try and guess whether your data is or needs to be an image pyramid.
+You can use the `is_pyramid` keyword argument to specify if you data is an image pyramid or not.
+If you don't provide this value then will try and guess whether your data is or needs to be an image pyramid.
 
 ## 3D rendering of images
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer, allowing you to browse volumetric timeseries data and other high dimensional data. See for example these cells undergoing mitosis in this volumetric timeseries:
+All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer,
+allowing you to browse volumetric timeseries data and other high dimensional data.
+See for example these cells undergoing mitosis in this volumetric timeseries:
 
 ![image]({{ '/assets/tutorials/mitosis.gif' | relative_url }})
 
 ## viewing rgb vs luminance (grayscale) images
 
-In the above example we explicitly set the `rgb` keyword to be `True` because we knew we were working with an `rgb` image.
+In the above example we explicitly set the `rgb` keyword to be `True`
+because we knew we were working with an `rgb` image.
 
 ```python
 viewer = napari.view_image(data.astronaut(), rgb=True)
 ```
 
-If we had left that keyword argument out napari would have successfully guessed that we were trying to show an `rgb` or `rgba` image because the final dimension was 3 or 4. If you have a luminance image where the last dimension is 3 or 4 you can set the `rgb` property to `False` so napari handles the image correctly.
+If we had left that keyword argument out
+napari would have successfully guessed that we were trying to show an `rgb` or `rgba` image
+because the final dimension was 3 or 4.
+If you have a luminance image where the last dimension is 3 or 4
+you can set the `rgb` property to `False` so napari handles the image correctly.
 
-`rgb` data must either be `uint8`, corresponding to values between 0 and 255, or `float` and between 0 and 1. If the values are `float` and outside the 0 to 1 range they will be clipped.
+`rgb` data must either be `uint8`, corresponding to values between 0 and 255, or `float` and between 0 and 1.
+If the values are `float` and outside the 0 to 1 range they will be clipped.
 
 ## working with colormaps
 
-napari supports any colormap that is created with `vispy.color.Colormap`. We provide access to some standard colormaps that you can set using a string of their name. These include:
+napari supports any colormap that is created with `vispy.color.Colormap`.
+We provide access to some standard colormaps that you can set using a string of their name.
+These include:
 
 - PiYG
 - blue
@@ -123,9 +168,17 @@ Passing any of these as follows
 viewer = napari.view_image(data.moon(), colormap='red')
 ```
 
-will set the colormap of that image. You can also access the current colormap through the `layer.colormap` property which returns a tuple of the colormap name followed by the vispy colormap object. You can list all the available colormaps using `layer.colormaps`.
+will set the colormap of that image.
+You can also access the current colormap through the `layer.colormap` property
+which returns a tuple of the colormap name followed by the vispy colormap object.
+You can list all the available colormaps using `layer.colormaps`.
 
-It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object, see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap). Briefly, you can pass `Colormap` a list of length 3 or length 4 lists, corresponding to the `rgb` or `rgba` values at different points along the colormap. For example to make a diverging colormap the goes from red to blue through black and color a random array you can do the following:
+It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object,
+see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap).
+Briefly, you can pass `Colormap` a list of length 3 or length 4 lists,
+corresponding to the `rgb` or `rgba` values at different points along the colormap.
+For example to make a diverging colormap the goes from red to blue through black
+and color a random array you can do the following:
 
 ```python
 import numpy as np
@@ -142,17 +195,28 @@ with napari.gui_qt():
 
 ![image]({{ '/assets/tutorials/diverging_colormap.png' | relative_url }})
 
-Note in this example how we passed the colormap keyword argument as a tuple containing both a name for our new custom colormap and the colormap itself. If we had only passed the colormap it would have been given a default name.
+Note in this example how we passed the colormap keyword argument as a tuple containing both a name for our new custom colormap and the colormap itself.
+If we had only passed the colormap it would have been given a default name.
 
 The named colormap now appears in the dropdown menu along side a little thumbnail of the full range of the colormap.
 
 ## adjusting contrast limits
 
-Each image layer gets mapped through its colormap according to values called contrast limits. The contrast limits are a 2-tuple where the second value is larger than the first. The smaller contrast limit corresponds to the value of the image data that will get mapped to the color defined by 0 in the colormap. All values of image data smaller than this value will also get mapped to this color. The larger contrast limit corresponds to the value of the image data that will get mapped to the color defined by 1 in the colormap. All values of image data larger than this value will also get mapped to this color.
+Each image layer gets mapped through its colormap according to values called contrast limits.
+The contrast limits are a 2-tuple where the second value is larger than the first.
+The smaller contrast limit corresponds to the value of the image data that will get mapped to the color defined by 0 in the colormap.
+All values of image data smaller than this value will also get mapped to this color.
+The larger contrast limit corresponds to the value of the image data that will get mapped to the color defined by 1 in the colormap.
+All values of image data larger than this value will also get mapped to this color.
 
-For example you are looking at an image that has values between 0 and 100 with a standard `gray` colormap, and you set the contrast limits to `(20, 75)` Then all the pixels with values less than 20 will get mapped to black, the color corresponding to 0 in the colormap, and all pixels with values greater than 75 will get mapped to white, the color corresponding to 1 in the colormap. All other pixel values between 20 and 75 will get linearly mapped onto the range of colors between black and white.
+For example you are looking at an image that has values between 0 and 100 with a standard `gray` colormap,
+and you set the contrast limits to `(20, 75)`.
+Then all the pixels with values less than 20 will get mapped to black, the color corresponding to 0 in the colormap,
+and all pixels with values greater than 75 will get mapped to white, the color corresponding to 1 in the colormap.
+All other pixel values between 20 and 75 will get linearly mapped onto the range of colors between black and white.
 
-In napari you can set the contrast limits when creating an `Image` layer or on an existing layer using the `contrast_limits` keyword argument or property respectively.
+In napari you can set the contrast limits when creating an `Image` layer
+or on an existing layer using the `contrast_limits` keyword argument or property respectively.
 
 ```python
 viewer = napari.view_image(data.moon(), name='moon')
@@ -161,41 +225,69 @@ viewer.layers['moon'].contrast_limits=(100, 175)
 
 ![image]({{ '/assets/tutorials/contrast_limits.png' | relative_url }})
 
-Because the contrast limits are defined by two values the corresponding slider has two handles, one the adjusts the smaller value, one that adjusts the larger value.
+Because the contrast limits are defined by two values
+the corresponding slider has two handles,
+one the adjusts the smaller value,
+one that adjusts the larger value.
 
 As of right now adjusting the contras limits has no effect for `rgb` data.
 
-If no contrast limits are passed then napari will compute them. If your data is small then napari will just take the minimum and maximum values across your entire image. If your data is very large, this operation can be very time consuming and so if you have passed an image pyramid then napari will just use the top level of that pyramid, or it will use the minimum and maximum values across the top, middle, and bottom slices of your image. In general if working with big images it is recommended you explicitly set the contrast limits if you can.
+If no contrast limits are passed then napari will compute them.
+If your data is small, then napari will just take the minimum and maximum values across your entire image.
+If your data is very large, this operation can be very time consuming
+and so if you have passed an image pyramid then napari will just use the top level of that pyramid,
+or it will use the minimum and maximum values across the top, middle, and bottom slices of your image.
+In general if working with big images it is recommended you explicitly set the contrast limits if you can.
 
-Currently if you pass contrast limits as a keyword argument to a layer then full extent of the contrast limits range slider will be set to those values.
+Currently if you pass contrast limits as a keyword argument to a layer
+then full extent of the contrast limits range slider will be set to those values.
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for many cell biology applications where you have multiple different components of a cell labeled in different colors. For example:
+The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
+This mode is very useful for many cell biology applications
+where you have multiple different components of a cell labeled in different colors.
+For example:
 
 ![image]({{ '/assets/tutorials/blending.png' | relative_url }})
 
 ## layer interpolation
 
-We support a variety of interpolation modes when viewing 2D slices. In the default mode `nearest` each pixel is represented as a small square of specified size. As you zoom in you will eventually see each pixel. In other modes neighbouring pixels are blended together according to different functions, for example `bicubic`, which can lead to smoother looking images. For most scientific use-cases `nearest` is recommended because it does not introduce more artificial blurring.  These modes have no effect when viewing 3D slices.
+We support a variety of interpolation modes when viewing 2D slices.
+In the default mode `nearest` each pixel is represented as a small square of specified size.
+As you zoom in you will eventually see each pixel.
+In other modes neighbouring pixels are blended together according to different functions,
+for example `bicubic`, which can lead to smoother looking images.
+For most scientific use-cases `nearest` is recommended because it does not introduce more artificial blurring.
+These modes have no effect when viewing 3D slices.
 
 ## layer rendering
 
-When viewing 3D slices we support a variety of rendering modes. The default mode `mip`, or maximum intensity projection, will combine voxels at different distances from the camera according to a maximum intensity projection to create the 2D image that is then displayed on the screen. This mode works well for many biological images such as these cells growing in culture:
+When viewing 3D slices we support a variety of rendering modes.
+The default mode `mip`, or maximum intensity projection,
+will combine voxels at different distances from the camera according to a maximum intensity projection
+to create the 2D image that is then displayed on the screen.
+This mode works well for many biological images such as these cells growing in culture:
 
 ![image]({{ '/assets/tutorials/rendering.png' | relative_url }})
 
@@ -203,22 +295,35 @@ When viewing 2D slices the rendering mode has no effect.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic volumes where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively
+according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic volumes
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Image` layer, including how to create one and control its properties. To learn more about some of the other layer types that **napari** supports checkout some more of our tutorials listed below. The [labels layer](./labels) tutorial is a great one to try next as labels layers are an extension of our image layers used for labeling regions of images.
+Hopefully this tutorial has given you a detailed understanding of the `Image` layer,
+including how to create one and control its properties.
+To learn more about some of the other layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [labels layer](./labels) tutorial is a great one to try next
+as labels layers are an extension of our image layers used for labeling regions of images.
 
 {% include footer.md %}

--- a/fundamentals/installation.md
+++ b/fundamentals/installation.md
@@ -2,29 +2,27 @@
 
 Welcome to the **napari** installation tutorial!
 
-This tutorial will teach you how to do a clean install of **napari**. It is
-aimed at people that just want to use napari. For people also interested in
-contributing to napari please check our [contributing
-guidelines](https://github.com/napari/napari/blob/master/docs/developers/CONTRIBUTING.md)
-for more advanced installation procedures. At the end of the tutorial you should
-have napari successfully installed on your computer and be able to make the
-napari viewer appear.
+This tutorial will teach you how to do a clean install of **napari**.
+It is aimed at people that just want to use napari.
+For people also interested in contributing to napari
+please check our [contributing guidelines](https://github.com/napari/napari/blob/master/docs/developers/CONTRIBUTING.md) for more advanced installation procedures.
+At the end of the tutorial you should have napari successfully installed on your computer
+and be able to make the napari viewer appear.
 
 ## installation
 
 ### from pip, with "batteries included"
 
-napari can be installed on most macOS, Linux, and Windows systems with
-Python 3.6, 3.7 and 3.8 using pip:
+napari can be installed on most macOS, Linux, and Windows systems with Python 3.6, 3.7 and 3.8 using pip:
 
 ```sh
 pip install napari[all]
 ```
 
-Note: while not strictly required, it is *highly* recommended to install
-napari into a clean virtual environment using an environment manager like
+Note: while not strictly required, it is *highly* recommended to install napari into a clean virtual environment using an environment manager like
 [conda](https://docs.conda.io/en/latest/miniconda.html) or
-[venv](https://docs.python.org/3/library/venv.html).  For example, with `conda`:
+[venv](https://docs.python.org/3/library/venv.html).
+For example, with `conda`:
 
 ```sh
 conda create -y -n napari-env python=3.8
@@ -52,8 +50,7 @@ pip install -e .[all]
 
 ## checking it worked
 
-After installation you should be able to launch napari from the command line by
-simply running
+After installation you should be able to launch napari from the command line by simply running
 
 ```sh
 napari
@@ -75,21 +72,20 @@ pip install napari[all] --upgrade
 
 > ℹ️ **NOTE**
 >
-> napari needs a library called [Qt](https://www.qt.io/) to run its user
-> interface (UI). In Python, there are two alternative libraries to run this,
+> napari needs a library called [Qt](https://www.qt.io/) to run its user interface (UI).
+> In Python, there are two alternative libraries to run this,
 > called [PyQt5](https://www.riverbankcomputing.com/software/pyqt/download5) and
-> [PySide2](https://doc.qt.io/qtforpython/). By default, we don't choose for
-> you, and simply running `pip install napari` will not install either. You
-> *might* already have one of them installed in your environment, thanks to
-> other scientific packages such as Spyder or matplotlib. If neither is
-> available, running napari will result in an error message asking you to
-> install one of them.
+> [PySide2](https://doc.qt.io/qtforpython/).
+> By default, we don't choose for you, and simply running `pip install napari` will not install either.
+> You *might* already have one of them installed in your environment,
+> thanks to other scientific packages such as Spyder or matplotlib.
+> If neither is available, running napari will result in an error message asking you to install one of them.
 
 As mentioned above, `pip install napari[all]` will (currently) install
 [PyQt](https://www.riverbankcomputing.com/software/pyqt/intro).
 
-If you wish to use [PySide2](https://wiki.qt.io/Qt_for_Python), or specify the
-backend explicitly you may do using either
+If you wish to use [PySide2](https://wiki.qt.io/Qt_for_Python),
+or specify the backend explicitly you may do using either
 
 ```sh
 pip install napari[pyside2]
@@ -98,14 +94,13 @@ pip install napari[pyside2]
 pip install napari[pyqt5]
 ```
 
-Note: if you switch backends, it's a good idea to `pip uninstall` the one you're
-not using.
+Note: if you switch backends, it's a good idea to `pip uninstall` the one you're not using.
 
 ## bug reports
 
-If you are running into issues, please open a new issue on our [issue
-tracker](https://github.com/napari/napari/issues) and include the output of the
-following command
+If you are running into issues,
+please open a new issue on our [issue tracker](https://github.com/napari/napari/issues)
+and include the output of the following command
 
 ```sh
 napari --info
@@ -113,14 +108,13 @@ napari --info
 
 ## help
 
-We're a community partner on the [imagesc
-forum](https://forum.image.sc/tags/napari) and all usage support requests should
-be posted on the forum with the tag `napari`. We look forward to interacting
-with you there.
+We're a community partner on the [imagesc forum](https://forum.image.sc/tags/napari)
+and all usage support requests should be posted on the forum with the tag `napari`.
+We look forward to interacting with you there.
 
 ## next steps
 
-Now that you've got napari installed, checkout our [getting
-started](./getting_started) tutorial to start learning how to use it!
+Now that you've got napari installed,
+checkout our [getting started](./getting_started) tutorial to start learning how to use it!
 
 {% include footer.md %}

--- a/fundamentals/labels.md
+++ b/fundamentals/labels.md
@@ -47,7 +47,8 @@ with napari.gui_qt():
 
 Both `view_labels` and `add_labels` have the following doc strings:
 
-```
+```python
+"""
 Parameters
 ----------
 image : np.ndarray
@@ -69,6 +70,7 @@ Returns
 -------
 layer : napari.layers.Labels
     The newly-created labels layer.
+"""
 ```
 
 ## labels data

--- a/fundamentals/labels.md
+++ b/fundamentals/labels.md
@@ -2,19 +2,39 @@
 
 Welcome to the tutorial on the **napari** `Labels` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Labels` layer, including using the layer to display the results of image segmentation analyses, and how to manually segment images using the paintbrush and fill buckets. At the end of the tutorial you should understand how to add a labels image and edit it from the GUI and from the console.
+This tutorial will teach you about the **napari** `Labels` layer,
+including using the layer to display the results of image segmentation analyses,
+and how to manually segment images using the paintbrush and fill buckets.
+At the end of the tutorial you should understand how to add a labels image and edit it from the GUI and from the console.
 
-The labels layer allows you to take an array of integers and display each integer as a different random color, with the background color 0 rendered as transparent.
+The labels layer allows you to take an array of integers and display each integer as a different random color,
+with the background color 0 rendered as transparent.
 
-The labels layer therefore very useful for segmentation tasks where each pixel is assigned to a different class, as occurs in semantic segmentation, or where pixels corresponding to different objects all get assigned the same label, as occurs in instance segmentation.
+The labels layer therefore very useful for segmentation tasks where each pixel is assigned to a different class,
+as occurs in semantic segmentation,
+or where pixels corresponding to different objects all get assigned the same label,
+as occurs in instance segmentation.
 
 ## a simple example
 
-You can create a new viewer and add an labels image in one go using the `napari.view_labels` method, or if you already have an existing viewer, you can add a labels image to it using `viewer.add_labels`. The api of both methods is the same. In these examples we'll mainly use `add_labels` to overlay a labels image onto on image.
+You can create a new viewer and add an labels image in one go using the `napari.view_labels` method,
+or if you already have an existing viewer,
+you can add a labels image to it using `viewer.add_labels`.
+The api of both methods is the same.
+In these examples we'll mainly use `add_labels` to overlay a labels image onto on image.
 
-In this example of instance segmentation we will find and segment each of the coins in an image, assigning each one an integer label, and then overlay the results on the original image as follows:
+In this example of instance segmentation we will find and segment each of the coins in an image,
+assigning each one an integer label,
+and then overlay the results on the original image as follows:
 
 ```python
 from skimage import data
@@ -75,85 +95,146 @@ layer : napari.layers.Labels
 
 ## labels data
 
-The labels layer is a subclass of the `Image` layer and as such can support the same numpy-like arrays, including [dask arrays](https://docs.dask.org/en/stable/array.html), an [xarrays](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html), and [zarr arrays](https://zarr.readthedocs.io/en/stable/api/core.html). A labels layer though must be integer valued, and the background label must be 0.
+The labels layer is a subclass of the `Image` layer and as such can support the same numpy-like arrays,
+including [dask arrays](https://docs.dask.org/en/stable/array.html),
+an [xarrays](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html),
+and [zarr arrays](https://zarr.readthedocs.io/en/stable/api/core.html).
+A labels layer though must be integer valued, and the background label must be 0.
 
-Because the labels layer subclasses the image layer it inherits the great properties of the image layer, like supporting lazy loading and image pyramids for big data layers. For more information about both these concepts see the details in the [image layer](./image) tutorial.
+Because the labels layer subclasses the image layer it inherits the great properties of the image layer,
+like supporting lazy loading and image pyramids for big data layers.
+For more information about both these concepts see the details in the [image layer](./image) tutorial.
 
 ## creating a new labels layer
 
-As you can edit a labels layer using the paintbrush and fill bucket, it is possible to create a brand new empty labels layers by clicking the new labels layer button above the layers list. The shape of the new labels layer will match the size of any currently existing image layers, allowing you to paint on top of them.
+As you can edit a labels layer using the paintbrush and fill bucket,
+it is possible to create a brand new empty labels layers by clicking the new labels layer button above the layers list.
+The shape of the new labels layer will match the size of any currently existing image layers,
+allowing you to paint on top of them.
 
 ## non-editable mode
 
 If you want to disable editing of the labels layer you can set the `editable` property of the layer to `False`.
 
-As note in the section on 3D rendering, when using 3D rendering the labels layer is not editable. Similarly for now, a labels layer where the data is represented as an image pyramid is not editable.
+As note in the section on 3D rendering, when using 3D rendering the labels layer is not editable.
+Similarly for now, a labels layer where the data is represented as an image pyramid is not editable.
 
 ## 3D rendering of labels
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer, allowing you to browse volumetric timeseries data and other high dimensional data. See for example the labeled blobs in 3D in the `examples/nD_labels.py`:
+All our layers can be rendered in both 2D and 3D mode,
+and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer,
+allowing you to browse volumetric timeseries data and other high dimensional data.
+See for example the labeled blobs in 3D in the `examples/nD_labels.py`:
 
 ![image]({{ '/assets/tutorials/nD_labels.png' | relative_url }})
 
-Note though that when entering 3D rendering mode the colorpicker, paintbrush, and fill bucket options which allow for layer editing are all disabled. Those options are only supported when viewing a layer using 2D rendering.
+Note though that when entering 3D rendering mode
+the colorpicker, paintbrush, and fill bucket options which allow for layer editing are all disabled.
+Those options are only supported when viewing a layer using 2D rendering.
 
 ## pan and zoom mode
 
-The default mode of the labels layer is to support panning and zooming, as in the image layer. This mode is represent by the magnifying glass in the layers control panel, and while it is selected editing the layer is not possible. Continue reading to learn how to use some of the editing modes. You can always return to pan and zoom mode by pressing the `Z` key when the labels layer is selected.
+The default mode of the labels layer is to support panning and zooming, as in the image layer.
+This mode is represent by the magnifying glass in the layers control panel,
+and while it is selected editing the layer is not possible.
+Continue reading to learn how to use some of the editing modes.
+You can always return to pan and zoom mode by pressing the `Z` key when the labels layer is selected.
 
 ## shuffling label colors
 
-The color that each integer gets assigned is random, aside from 0 which always gets assigned to be transparent. The colormap we use is designed such that nearby integers get assigned very different colors. The exact colors that get assigned as determined by a [random seed](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.random.seed.html) and changing that seed will shuffle the colors that each label gets assigned. Changing the seed can be done by clicking on the `shuffle colors` button in the layers control panel. Shuffling colors can be useful as some colors may be hard to distinguish from the background or nearby objects.
+The color that each integer gets assigned is random, aside from 0 which always gets assigned to be transparent.
+The colormap we use is designed such that nearby integers get assigned very different colors.
+The exact colors that get assigned as determined by a [random seed](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.random.seed.html)
+and changing that seed will shuffle the colors that each label gets assigned.
+Changing the seed can be done by clicking on the `shuffle colors` button in the layers control panel.
+Shuffling colors can be useful as some colors may be hard to distinguish from the background or nearby objects.
 
 ## selecting a label
 
-A particular label can be selected either using the label combobox inside the layers control panel and typing in the value of the desired label or using the plus / minus buttons, or by selecting the color picker tool and then clicking on a pixel with the desired label in the image. When a label is selected you will see its integer inside the label combobox and the color or the label shown in the thumbnail next to the label combobox. If the 0 label is selected then a checkerboard pattern is shown in the thumbnail to represent the transparent color.
+A particular label can be selected either using the label combobox inside the layers control panel
+and typing in the value of the desired label or using the plus / minus buttons,
+or by selecting the color picker tool and then clicking on a pixel with the desired label in the image.
+When a label is selected you will see its integer inside the label combobox
+and the color or the label shown in the thumbnail next to the label combobox.
+If the 0 label is selected then a checkerboard pattern is shown in the thumbnail to represent the transparent color.
 
 You can quickly select the color picker by pressing the `L` key when the labels layer is selected.
 
 You can set the selected label to be 0, the background label, by pressing `E`.
 
-You can set the selected label to be one larger than the current largest label by pressing `M`. This selection will guarantee that you are then using a label that hasn't been used before.
+You can set the selected label to be one larger than the current largest label by pressing `M`.
+This selection will guarantee that you are then using a label that hasn't been used before.
 
 You can also increment or decrement the currently selected label by pressing the `I` or `D` key respectively.
 
 ## painting in the labels layer
 
-One of the major use cases for the labels layer is to manually edit or create image segmentations. One of the tools that can be used for manual editing is the `paintbrush`, that can be made active from by clicking the paintbrush icon in the layers control panel. Once the paintbrush is enable the pan and zoom functionality of the  viewer canvas gets disabled and you are able to paint onto the canvas. You can temporarily re-enable pan and zoom by pressing and holding the spacebar. This feature can be useful if you want to move around the labels layer as you paint.
+One of the major use cases for the labels layer is to manually edit or create image segmentations.
+One of the tools that can be used for manual editing is the `paintbrush`,
+that can be made active from by clicking the paintbrush icon in the layers control panel.
+Once the paintbrush is enable the pan and zoom functionality of the  viewer canvas gets disabled
+and you are able to paint onto the canvas.
+You can temporarily re-enable pan and zoom by pressing and holding the spacebar.
+This feature can be useful if you want to move around the labels layer as you paint.
 
-When you start painting the label that you are painting with, and the color that you will see are determined by the selected label. Note there is no explicit eraser tool, instead you just need to make the selected label 0 and then you are effectively painting with the background color. Remember you can use the color picker tool at any point to change the selected label.
+When you start painting the label that you are painting with,
+and the color that you will see are determined by the selected label.
+Note there is no explicit eraser tool,
+instead you just need to make the selected label 0 and then you are effectively painting with the background color.
+Remember you can use the color picker tool at any point to change the selected label.
 
-You can adjust the size of your paintbrush using the brush size slider, making it as small as a single pixel for very detailed painting.
+You can adjust the size of your paintbrush using the brush size slider,
+making it as small as a single pixel for very detailed painting.
 
-If you have a multidimensional labels layer then your paintbrush will only edit data in the visible slice by default; however, if you enable the `n_dimensional` property and paintbrush then your paintbrush will extend out into neighbouring slices according to its size.
+If you have a multidimensional labels layer
+then your paintbrush will only edit data in the visible slice by default;
+however, if you enable the `n_dimensional` property and paintbrush
+then your paintbrush will extend out into neighbouring slices according to its size.
 
 You can quickly select the paintbrush by pressing the `P` key when the labels layer is selected.
 
 ## using the fill bucket
 
-Sometimes you might want to replace an entire label with a different label. This could be because you want to make two touching regions have the same label, or you want to just replace one label with a different one, or maybe you have painted around the edge of a region and you want to quickly fill in its inside. To do this you can select the `fill bucket` by clicking on the droplet icon in the layer controls panel and then click on a target region of interest in the layer. The fill bucket will fill using the currently selected label.
+Sometimes you might want to replace an entire label with a different label.
+This could be because you want to make two touching regions have the same label,
+or you want to just replace one label with a different one,
+or maybe you have painted around the edge of a region and you want to quickly fill in its inside.
+To do this you can select the `fill bucket` by clicking on the droplet icon in the layer controls panel
+and then click on a target region of interest in the layer.
+The fill bucket will fill using the currently selected label.
 
-By default the fill bucket will only change contiguous or connected pixels of the same label as the pixel that is clicked on. If you want to change all the pixels of that label regardless of where they are in the slice then you can set the `contiguous` property or checkbox to `False`.
+By default the fill bucket will only change contiguous or connected pixels of the same label as the pixel that is clicked on.
+If you want to change all the pixels of that label regardless of where they are in the slice
+then you can set the `contiguous` property or checkbox to `False`.
 
-If you have a multidimensional labels layer then your fill bucket will only edit data in the visible slice by default; however, if you enable the `n_dimensional` property and paintbrush then your fill bucket will extend out into neighbouring slices, either to all pixels with that label in the layer, or only connected pixels depending on if the contiguous property is disabled or not.
+If you have a multidimensional labels layer then your fill bucket will only edit data in the visible slice by default;
+however, if you enable the `n_dimensional` property and paintbrush
+then your fill bucket will extend out into neighbouring slices,
+either to all pixels with that label in the layer,
+or only connected pixels depending on if the contiguous property is disabled or not.
 
 You can quickly select the fill bucket by pressing the `F` key when the labels layer is selected.
 
 ## creating, deleting, merging and splitting connected components
 
-Using the `color picker`, `paintbrush` and `fill bucket` tools one can create and edit object segmentation maps. Below we show how to use these tools to by perform common editing tasks on connected components (keep the `contiguous` box checked).
+Using the `color picker`, `paintbrush` and `fill bucket` tools one can create and edit object segmentation maps.
+Below we show how to use these tools to by perform common editing tasks on connected components (keep the `contiguous` box checked).
 
 **drawing a connected component**:
 
 ![image]({{ '/assets/tutorials/draw_component.gif' | relative_url }})
 
-Press `M` to select a new label color. Select the `paintbrush` tool and draw a closed contour around the object. Select the `fill bucket` tool and click inside the contour to assign the label to all pixels of the object.
+Press `M` to select a new label color.
+Select the `paintbrush` tool and draw a closed contour around the object.
+Select the `fill bucket` tool and click inside the contour to assign the label to all pixels of the object.
 
 **selecting a connected component**:
 
 ![image]({{ '/assets/tutorials/delete_label.gif' | relative_url }})
 
-select the background label with the `color picker` (alternative: press keyboard shortcut `E`), then use the `fill bucket` to set all pixels of the connected component to background.
+select the background label with the `color picker` (alternative: press keyboard shortcut `E`),
+then use the `fill bucket` to set all pixels of the connected component to background.
 
 **merging connected components**:
 
@@ -165,49 +246,75 @@ select the label of one of the components with the `color picker` tool and then 
 
 ![image]({{ '/assets/tutorials/split_label.gif' | relative_url }})
 
-splitting a connected component will introduce an additional object, therefore press `M` to select a label number that is not already in use. Use the paintbrush tool to draw a dividing line, then assign the new label to one of the parts with the `fill bucket`. 
+splitting a connected component will introduce an additional object,
+therefore press `M` to select a label number that is not already in use.
+Use the paintbrush tool to draw a dividing line,
+then assign the new label to one of the parts with the `fill bucket`.
 
 ## undo / redo functionality
 
-When painting or using the fill bucket it can be easy to make a mistake that you might want to undo or then redo. For the labels layer we support an undo with `ctrl-Z` and redo with `shift-ctrl-Z`. We plan to support this sort of functionality more generally, but for now these actions will undo the most recent painting or filling event, up to 100 events in the past.
+When painting or using the fill bucket it can be easy to make a mistake that you might want to undo or then redo.
+For the labels layer we support an undo with `ctrl-Z` and redo with `shift-ctrl-Z`.
+We plan to support this sort of functionality more generally,
+but for now these actions will undo the most recent painting or filling event, up to 100 events in the past.
 
 If you have multidimensional data then adjusting the currently viewed slice will cause the undo history to be reset.
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for visualizing multiple layers at the same time.
+The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
+This mode is very useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic volumes where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument
+that will rescale the layer multiplicatively according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic volumes
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Labels` layer, including how to create one and control its properties. To learn more about some of the other layer types that **napari** supports checkout some more of our tutorials listed below. The [points layer](./points) tutorial is a great one to try next as points are one of our simplest shape-like layers.
+Hopefully this tutorial has given you a detailed understanding of the `Labels` layer,
+including how to create one and control its properties.
+To learn more about some of the other layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [points layer](./points) tutorial is a great one to try next
+as points are one of our simplest shape-like layers.
 {% include footer.md %}

--- a/fundamentals/labels.md
+++ b/fundamentals/labels.md
@@ -19,7 +19,7 @@ At the end of the tutorial you should understand how to add a labels image and e
 The labels layer allows you to take an array of integers and display each integer as a different random color,
 with the background color 0 rendered as transparent.
 
-The labels layer therefore very useful for segmentation tasks where each pixel is assigned to a different class,
+The `Labels` layer is therefore especially useful for segmentation tasks where each pixel is assigned to a different class,
 as occurs in semantic segmentation,
 or where pixels corresponding to different objects all get assigned the same label,
 as occurs in instance segmentation.
@@ -28,11 +28,11 @@ as occurs in instance segmentation.
 
 You can create a new viewer and add an labels image in one go using the `napari.view_labels` method,
 or if you already have an existing viewer,
-you can add a labels image to it using `viewer.add_labels`.
+you can add a `Labels` image to it using `viewer.add_labels`.
 The api of both methods is the same.
-In these examples we'll mainly use `add_labels` to overlay a labels image onto on image.
+In these examples we'll mainly use `add_labels` to overlay a `Labels` image onto on image.
 
-In this example of instance segmentation we will find and segment each of the coins in an image,
+In this example of instance segmentation, we will find and segment each of the coins in an image,
 assigning each one an integer label,
 and then overlay the results on the original image as follows:
 
@@ -97,9 +97,9 @@ layer : napari.layers.Labels
 
 The labels layer is a subclass of the `Image` layer and as such can support the same numpy-like arrays,
 including [dask arrays](https://docs.dask.org/en/stable/array.html),
-an [xarrays](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html),
+[xarrays](http://xarray.pydata.org/en/stable/generated/xarray.DataArray.html),
 and [zarr arrays](https://zarr.readthedocs.io/en/stable/api/core.html).
-A labels layer though must be integer valued, and the background label must be 0.
+A `Labels` layer though must be integer valued, and the background label must be 0.
 
 Because the labels layer subclasses the image layer it inherits the great properties of the image layer,
 like supporting lazy loading and image pyramids for big data layers.
@@ -107,8 +107,8 @@ For more information about both these concepts see the details in the [image lay
 
 ## creating a new labels layer
 
-As you can edit a labels layer using the paintbrush and fill bucket,
-it is possible to create a brand new empty labels layers by clicking the new labels layer button above the layers list.
+As you can edit a `Labels` layer using the paintbrush and fill bucket,
+it is possible to create a brand-new empty labels layers by clicking the new labels layer button above the layers list.
 The shape of the new labels layer will match the size of any currently existing image layers,
 allowing you to paint on top of them.
 
@@ -117,13 +117,13 @@ allowing you to paint on top of them.
 If you want to disable editing of the labels layer you can set the `editable` property of the layer to `False`.
 
 As note in the section on 3D rendering, when using 3D rendering the labels layer is not editable.
-Similarly for now, a labels layer where the data is represented as an image pyramid is not editable.
+Similarly, for now, a labels layer where the data is represented as an image pyramid is not editable.
 
 ## 3D rendering of labels
 
 All our layers can be rendered in both 2D and 3D mode,
 and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer,
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer,
 allowing you to browse volumetric timeseries data and other high dimensional data.
 See for example the labeled blobs in 3D in the `examples/nD_labels.py`:
 
@@ -136,7 +136,7 @@ Those options are only supported when viewing a layer using 2D rendering.
 ## pan and zoom mode
 
 The default mode of the labels layer is to support panning and zooming, as in the image layer.
-This mode is represent by the magnifying glass in the layers control panel,
+This mode is represented by the magnifying glass in the layers control panel,
 and while it is selected editing the layer is not possible.
 Continue reading to learn how to use some of the editing modes.
 You can always return to pan and zoom mode by pressing the `Z` key when the labels layer is selected.
@@ -144,7 +144,7 @@ You can always return to pan and zoom mode by pressing the `Z` key when the labe
 ## shuffling label colors
 
 The color that each integer gets assigned is random, aside from 0 which always gets assigned to be transparent.
-The colormap we use is designed such that nearby integers get assigned very different colors.
+The colormap we use is designed such that nearby integers get assigned distinct colors.
 The exact colors that get assigned as determined by a [random seed](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.random.seed.html)
 and changing that seed will shuffle the colors that each label gets assigned.
 Changing the seed can be done by clicking on the `shuffle colors` button in the layers control panel.
@@ -157,7 +157,7 @@ and typing in the value of the desired label or using the plus / minus buttons,
 or by selecting the color picker tool and then clicking on a pixel with the desired label in the image.
 When a label is selected you will see its integer inside the label combobox
 and the color or the label shown in the thumbnail next to the label combobox.
-If the 0 label is selected then a checkerboard pattern is shown in the thumbnail to represent the transparent color.
+If the 0 label is selected, then a checkerboard pattern is shown in the thumbnail to represent the transparent color.
 
 You can quickly select the color picker by pressing the `L` key when the labels layer is selected.
 
@@ -166,15 +166,15 @@ You can set the selected label to be 0, the background label, by pressing `E`.
 You can set the selected label to be one larger than the current largest label by pressing `M`.
 This selection will guarantee that you are then using a label that hasn't been used before.
 
-You can also increment or decrement the currently selected label by pressing the `I` or `D` key respectively.
+You can also increment or decrement the currently selected label by pressing the `I` or `D` key, respectively.
 
 ## painting in the labels layer
 
 One of the major use cases for the labels layer is to manually edit or create image segmentations.
 One of the tools that can be used for manual editing is the `paintbrush`,
 that can be made active from by clicking the paintbrush icon in the layers control panel.
-Once the paintbrush is enable the pan and zoom functionality of the  viewer canvas gets disabled
-and you are able to paint onto the canvas.
+Once the paintbrush is enabled, the pan and zoom functionality of the  viewer canvas gets disabled,
+and you can paint onto the canvas.
 You can temporarily re-enable pan and zoom by pressing and holding the spacebar.
 This feature can be useful if you want to move around the labels layer as you paint.
 
@@ -185,7 +185,7 @@ instead you just need to make the selected label 0 and then you are effectively 
 Remember you can use the color picker tool at any point to change the selected label.
 
 You can adjust the size of your paintbrush using the brush size slider,
-making it as small as a single pixel for very detailed painting.
+making it as small as a single pixel for incredibly detailed painting.
 
 If you have a multidimensional labels layer
 then your paintbrush will only edit data in the visible slice by default;
@@ -204,8 +204,8 @@ To do this you can select the `fill bucket` by clicking on the droplet icon in t
 and then click on a target region of interest in the layer.
 The fill bucket will fill using the currently selected label.
 
-By default the fill bucket will only change contiguous or connected pixels of the same label as the pixel that is clicked on.
-If you want to change all the pixels of that label regardless of where they are in the slice
+By default, the fill bucket will only change contiguous or connected pixels of the same label as the pixel that is clicked on.
+If you want to change all the pixels of that label regardless of where they are in the slice,
 then you can set the `contiguous` property or checkbox to `False`.
 
 If you have a multidimensional labels layer then your fill bucket will only edit data in the visible slice by default;
@@ -216,9 +216,9 @@ or only connected pixels depending on if the contiguous property is disabled or 
 
 You can quickly select the fill bucket by pressing the `F` key when the labels layer is selected.
 
-## creating, deleting, merging and splitting connected components
+## creating, deleting, merging, and splitting connected components
 
-Using the `color picker`, `paintbrush` and `fill bucket` tools one can create and edit object segmentation maps.
+Using the `color picker`, `paintbrush`, and `fill bucket` tools one can create and edit object segmentation maps.
 Below we show how to use these tools to by perform common editing tasks on connected components (keep the `contiguous` box checked).
 
 **drawing a connected component**:
@@ -258,7 +258,7 @@ For the labels layer we support an undo with `ctrl-Z` and redo with `shift-ctrl-
 We plan to support this sort of functionality more generally,
 but for now these actions will undo the most recent painting or filling event, up to 100 events in the past.
 
-If you have multidimensional data then adjusting the currently viewed slice will cause the undo history to be reset.
+If you have multidimensional data, then adjusting the currently viewed slice will cause the undo history to be reset.
 
 ## layer visibility
 
@@ -275,15 +275,15 @@ that allow you to adjust the layer opacity between 0, fully invisible, and 1, fu
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
-This mode is very useful for visualizing multiple layers at the same time.
+This mode is especially useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
@@ -311,7 +311,7 @@ that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Labels` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Labels` layer,
 including how to create one and control its properties.
 To learn more about some of the other layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/points.md
+++ b/fundamentals/points.md
@@ -2,17 +2,43 @@
 
 Welcome to the tutorial on the **napari** `Points` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**,
+know how to launch the viewer,
+and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders
+see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Points` layer, including displays spots over an image that have been found in an automated fashion, or manually annotating an image with points. At the end of the tutorial you should understand how to add a points layer and edit it from the GUI and from the console.
+This tutorial will teach you about the **napari** `Points` layer,
+including displays spots over an image that have been found in an automated fashion,
+or manually annotating an image with points.
+At the end of the tutorial you should understand how to add a points layer
+and edit it from the GUI and from the console.
 
-The points layer allows you to display an NxD array of N points in D coordinates. You can adjust the size, face color, edge color of all of the points independently. You can also adjust the opactiy, edge width, and symbol representing all the points simultaneously.
+The points layer allows you to display an NxD array of N points in D coordinates.
+You can adjust the size, face color, edge color of all of the points independently.
+You can also adjust the opactiy, edge width, and symbol representing all the points simultaneously.
 
-Each data point can have annotations associated with it using the `Points.properties` dictionary. These properties can be used to set the face and edge colors of the points. For example, when displaying points of different classes/types, one could automatically set color the individual points by their respective class/type. For more details on point properties, see the "setting point edge and face color with properties" below or the [point annotation tutorial](../applications/annotate_points). 
+Each data point can have annotations associated with it using the `Points.properties` dictionary.
+These properties can be used to set the face and edge colors of the points.
+For example, when displaying points of different classes/types,
+one could automatically set color the individual points by their respective class/type.
+For more details on point properties,
+see the "setting point edge and face color with properties" below
+or the [point annotation tutorial](../applications/annotate_points).
 
 ## a simple example
 
-You can create a new viewer and add a set of points in one go using the `napari.view_points` method, or if you already have an existing viewer, you can add points to it using `viewer.add_points`. The api of both methods is the same. In these examples we'll mainly use `add_points` to overlay points onto on an existing image.
+You can create a new viewer and add a set of points in one go using the `napari.view_points` method,
+or if you already have an existing viewer,
+you can add points to it using `viewer.add_points`.
+The api of both methods is the same.
+In these examples we'll mainly use `add_points` to overlay points onto on an existing image.
 
 In this example of we will overlay some points on the image of an astronaut:
 
@@ -105,65 +131,127 @@ layer : napari.layers.Points
 
 ## points data
 
-The input data to the points layer must be an NxD numpy array containing the coordinates of N points in D dimensions. The ordering of these dimensions is the same as the ordering of the dimensions for image layers. This array is always accessible through the `layer.data` property and will grow or shrink as new points are either added or deleted.
+The input data to the points layer must be an NxD numpy array
+containing the coordinates of N points in D dimensions.
+The ordering of these dimensions is the same as the ordering of the dimensions for image layers.
+This array is always accessible through the `layer.data` property
+and will grow or shrink as new points are either added or deleted.
 
 ## using the points properties dictionary
 
-The `Points` layer can contain properties that annotate each point. `Points.properties` stores the properties in a dictionary where each key is the name of the property and the values are numpy arrays with a value for each point (i.e., length N for N points in `Points.data`). As we will see below, we can use the values in a property to set the display properties of the points (e.g., face color or edge color). To see the points properties in action, please see the [point annotation tutorial](../applications/annotate_points).
+The `Points` layer can contain properties that annotate each point.
+`Points.properties` stores the properties in a dictionary
+where each key is the name of the property
+and the values are numpy arrays with a value for each point (i.e., length N for N points in `Points.data`).
+As we will see below, we can use the values in a property to set the display properties of the points (e.g., face color or edge color).
+To see the points properties in action,
+please see the [point annotation tutorial](../applications/annotate_points).
 
 ## creating a new points layer
 
-As you can add new points to a points layer using the add points tool, it is possible to create a brand new empty points layers by clicking the new points layer button above the layers list. The shape of the points layer is defined by the points inside it, and so as you add new points the shape will adjust as needed. The dimension of the new points layer will default to the largest dimension of any layer currently in the viewer, or to 2 if no other layers are present in the viewer.
+As you can add new points to a points layer using the add points tool,
+it is possible to create a brand new empty points layers
+by clicking the new points layer button above the layers list.
+The shape of the points layer is defined by the points inside it,
+and so as you add new points the shape will adjust as needed.
+The dimension of the new points layer will default to the largest dimension of any layer currently in the viewer,
+or to 2 if no other layers are present in the viewer.
 
 ## non-editable mode
 
-If you want to disable editing of the points layer you can set the `editable` property of the layer to `False`.
+If you want to disable editing of the points layer
+you can set the `editable` property of the layer to `False`.
 
 As note in the section on 3D rendering, when using 3D rendering the points layer is not editable.
 
 ## 3D rendering of points
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer. See for example these points overlaid on an image in both 2D and 3D:
+All our layers can be rendered in both 2D and 3D mode,
+and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+See for example these points overlaid on an image in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/smFISH.gif' | relative_url }})
 
-Note though that when entering 3D rendering mode the point add, delete, and select tools are all disabled. Those options are only supported when viewing a layer using 2D rendering.
+Note though that when entering 3D rendering mode
+the point add, delete, and select tools are all disabled.
+Those options are only supported when viewing a layer using 2D rendering.
 
 ## pan and zoom mode
 
-The default mode of the points layer is to support panning and zooming, as in the image layer. This mode is represent by the magnifying glass in the layers control panel, and while it is selected editing the layer is not possible. Continue reading to learn how to use some of the editing modes. You can always return to pan and zoom mode by pressing the `Z` key when the points layer is selected.
+The default mode of the points layer is to support panning and zooming, as in the image layer.
+This mode is represent by the magnifying glass in the layers control panel,
+and while it is selected editing the layer is not possible.
+Continue reading to learn how to use some of the editing modes.
+You can always return to pan and zoom mode by pressing the `Z` key when the points layer is selected.
 
 ## adding, deleting, and selecting points
 
-New points can be added using the point adding tool. This tool can be selected from layer controls panel. Points can then be added by clicking in the canvas. If you have a multidimensional points layer then the coordinates of the new point will keep track of the currently viewed slice that you added the point too. You can quickly select the add points tool by pressing the `P` key when the points layer is selected.
+New points can be added using the point adding tool.
+This tool can be selected from layer controls panel.
+Points can then be added by clicking in the canvas.
+If you have a multidimensional points layer
+then the coordinates of the new point will keep track of the currently viewed slice that you added the point too.
+You can quickly select the add points tool by pressing the `P` key when the points layer is selected.
 
-You can select a point by selecting the select points tool and then clicking on that point. You can select multiple points by continuing to shift click on additional points, or by dragging a bounding box around the points you want to select. You can quickly select the select points tool by pressing the `S` key when the points layer is selected.
+You can select a point by selecting the select points tool and then clicking on that point.
+You can select multiple points by continuing to shift click on additional points,
+or by dragging a bounding box around the points you want to select.
+You can quickly select the select points tool by pressing the `S` key when the points layer is selected.
 
 You can select all the points in the currently viewed slice by clicking the `A` key if you are in select mode.
 
 Once selected you can delete the selected points by clicking on the delete button in the layer controls panel or pressing the delete key.
 
-When using these point editing tools the pan and zoom functionality of the viewer canvas is disabled and you are able to edit the layer. You can temporarily re-enable pan and zoom by pressing and holding the spacebar. This feature can be useful if you want to move around the points layer as you edit it.
+When using these point editing tools
+the pan and zoom functionality of the viewer canvas is disabled and you are able to edit the layer.
+You can temporarily re-enable pan and zoom by pressing and holding the spacebar.
+This feature can be useful if you want to move around the points layer as you edit it.
 
 ## changing points size
 
-Each point can have a different size. You can pass a list or 1-dimensional array of points through the size keyword argument to initialize the layer with points of different sizes. These sizes are then accessible through the `sizes` property. If you pass a single size then all points will get initialized with that size. Points can be pseduo-visualized as n-dimensionsal if the `n-dimensional` property is set to `True` or the `n-dimensional` checkbox is checked. In this setting when viewing different slices of the layer points will appear in the neighbouring slices to the ones in which they are located with a size scaled by the distance from their center to that slice. This feature can be very useful when visualizing 2D slices of points that are located in a 3D volume.
+Each point can have a different size.
+You can pass a list or 1-dimensional array of points through the size keyword argument
+to initialize the layer with points of different sizes.
+These sizes are then accessible through the `sizes` property.
+If you pass a single size then all points will get initialized with that size.
+Points can be pseduo-visualized as n-dimensionsal if the `n-dimensional` property is set to `True`
+or the `n-dimensional` checkbox is checked.
+In this setting when viewing different slices of the layer
+points will appear in the neighbouring slices to the ones in which they are located
+with a size scaled by the distance from their center to that slice.
+This feature can be very useful when visualizing 2D slices of points that are located in a 3D volume.
 
-Points can also be resized within the GUI by first selecting them and then adjusting the point size slider. If no points are selected then adjusting the slider value will only serve to initialize the size for new points that are about to be added. The value of the size of the next point to be added can be found in the `layer.size` property. Note this property is different from `layer.sizes` which contains the current sizes of all the points.
+Points can also be resized within the GUI by first selecting them and then adjusting the point size slider.
+If no points are selected then adjusting the slider value will only serve to initialize the size for new points that are about to be added.
+The value of the size of the next point to be added can be found in the `layer.size` property.
+Note this property is different from `layer.sizes` which contains the current sizes of all the points.
 
 ## changing points edge and face color
 
-Individual points can each have different edge and face colors. You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively, or you can edit them from the GUI. The colors of each of the points are available as lists under the `layer.edge_colors` and `layer.face_colors` properties. Similar to the `sizes` and `size` properties these properties are different from the `layer.edge_color` and `layer.face_color` properties that will determine the color of the next point to be added or any currently selected points.
+Individual points can each have different edge and face colors.
+You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively,
+or you can edit them from the GUI.
+The colors of each of the points are available as lists under the `layer.edge_colors` and `layer.face_colors` properties.
+Similar to the `sizes` and `size` properties
+these properties are different from the `layer.edge_color` and `layer.face_color` properties
+that will determine the color of the next point to be added or any currently selected points.
 
-To change the point color properties from the GUI you must first select the points whose properties you want to change, otherwise you will just be initializing the property for the next point you add.
+To change the point color properties from the GUI
+you must first select the points whose properties you want to change,
+otherwise you will just be initializing the property for the next point you add.
 
 ## setting point edge and face color with properties
 
-Point edge and face colors can be set as a function of a property in `Points.properties`. There are two ways that the values in properties can be mapped to colors: (1) color cycles and (2) colormaps.
+Point edge and face colors can be set as a function of a property in `Points.properties`.
+There are two ways that the values in properties can be mapped to colors: (1) color cycles and (2) colormaps.
 
-Color cycles are sets of colors that are mapped to categorical properties. The colors are repeated if the number of unique property values is greater than the number of colors in the color cycle.
+Color cycles are sets of colors that are mapped to categorical properties.
+The colors are repeated if the number of unique property values is greater than the number of colors in the color cycle.
 
-Colormaps are a continuum of colors that are mapped to a continuous property value. The available colormaps are listed below (colormaps are from [vispy](http://vispy.org/color.html#vispy.color.Colormap)). For some guidance on choosing colormaps, see the [matplotlib colormap docs](https://matplotlib.org/3.2.0/tutorials/colors/colormaps.html).
+Colormaps are a continuum of colors that are mapped to a continuous property value.
+The available colormaps are listed below (colormaps are from [vispy](http://vispy.org/color.html#vispy.color.Colormap)).
+For some guidance on choosing colormaps, see the [matplotlib colormap docs](https://matplotlib.org/3.2.0/tutorials/colors/colormaps.html).
 
 * autumn
 * blues
@@ -188,7 +276,8 @@ Colormaps are a continuum of colors that are mapped to a continuous property val
 
 ### setting edge or face color with a color cycle
 
-Here we will set the edge color of the markers with a color cycle on a property. To do the same for a face color, substitute `face_color` for `edge_color` in the example snippet below.
+Here we will set the edge color of the markers with a color cycle on a property.
+To do the same for a face color, substitute `face_color` for `edge_color` in the example snippet below.
 
 ```python
 from skimage import data
@@ -213,11 +302,18 @@ with napari.gui_qt():
 
 ![image]({{ '/assets/tutorials/points_edge_color_cycle.png' | relative_url }})
 
-In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`. The values of each property is stored in a numpy ndarray with length 3 since there were three coordinates provided in `points`. We set the edge color as a function of the `good_point` property by providing the keyword argument `edge_color='good_point'` to the `viewer.add_points()` method. We set the color cycle via the `edge_color_cycle` keyword argument (`edge_color_cycle=['magenta', 'green']`). The color cycle can be provided as a list of colors (a list of strings or a (M x 4) array of M RGBA colors).
+In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`.
+The values of each property is stored in a numpy ndarray with length 3
+since there were three coordinates provided in `points`.
+We set the edge color as a function of the `good_point` property
+by providing the keyword argument `edge_color='good_point'` to the `viewer.add_points()` method.
+We set the color cycle via the `edge_color_cycle` keyword argument (`edge_color_cycle=['magenta', 'green']`).
+The color cycle can be provided as a list of colors (a list of strings or a (M x 4) array of M RGBA colors).
 
 ### setting edge or face color with a colormap
 
-Here we will set the face color of the markers with a color cycle on a property. To do the same for a face color, substitute `edge_color` for `face_color` in the example snippet below.
+Here we will set the face color of the markers with a color cycle on a property.
+To do the same for a face color, substitute `edge_color` for `face_color` in the example snippet below.
 
 ```python
 from skimage import data
@@ -241,49 +337,79 @@ with napari.gui_qt():
 
 ![image]({{ '/assets/tutorials/points_face_colormap.png' | relative_url }})
 
-In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`. The values of each property is stored in a numpy ndarray with length 3 since there were three coordinates provided in `points`. We set the face color as a function of the `confidence` property by providing the keyword argument `face_color='confidence'` to the `viewer.add_points()` method. We set the colormap to viridis using the `face_colormap` keyword argument (`face_colormap='viridis'`).
+In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`.
+The values of each property is stored in a numpy ndarray with length 3
+since there were three coordinates provided in `points`.
+We set the face color as a function of the `confidence` property
+by providing the keyword argument `face_color='confidence'` to the `viewer.add_points()` method.
+We set the colormap to viridis using the `face_colormap` keyword argument (`face_colormap='viridis'`).
 
 ## changing the points symbol
 
-The symbol for the points layer is a global property for the layer. All points must have the same symbol. You can set the symbol on the loading of the layer using the `symbol` keyword argument, or you can change it from the the GUI using the symbol dropdown menu. Since the symbol property applies to all the points you don't need to have any points selected for it to have an effect.
+The symbol for the points layer is a global property for the layer.
+All points must have the same symbol.
+You can set the symbol on the loading of the layer using the `symbol` keyword argument,
+or you can change it from the the GUI using the symbol dropdown menu.
+Since the symbol property applies to all the points
+you don't need to have any points selected for it to have an effect.
 
 ## copying and pasting points
 
-It is possible to copy and paste any selected points using the `ctrl-C` and `ctrl-V` keybindings respectively. If you have a multidimensional points layer you can copy points from one slice to another by pasting them into the new slice. The coordinates of the points in the visible dimensions will be in the same place on the new slice as in the old slice, but the rest of the coordinates will be updated with the new slice values.
+It is possible to copy and paste any selected points using the `ctrl-C` and `ctrl-V` keybindings respectively.
+If you have a multidimensional points layer you can copy points from one slice to another by pasting them into the new slice.
+The coordinates of the points in the visible dimensions will be in the same place on the new slice as in the old slice,
+but the rest of the coordinates will be updated with the new slice values.
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible. The opacity value applies globally to all the points in the layer, and so you don't need to have any points selected for it to have an effect.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+The opacity value applies globally to all the points in the layer,
+and so you don't need to have any points selected for it to have an effect.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for visualizing multiple layers at the same time.
+The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
+This mode is very useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic data where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument
+that will rescale the layer multiplicatively according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic data
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## putting it all together
 
@@ -293,6 +419,11 @@ Here you can see an example of adding, selecting, deleting points and change the
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Points` layer, including how to create one and control its properties. To learn more about some of the other layer types that **napari** supports checkout some more of our tutorials listed below. The [shapes layer](./shapes) tutorial is a great one to try next as it describes more complex shapes and interactivity.
+Hopefully this tutorial has given you a detailed understanding of the `Points` layer,
+including how to create one and control its properties.
+To learn more about some of the other layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [shapes layer](./shapes) tutorial is a great one to try next
+as it describes more complex shapes and interactivity.
 
 {% include footer.md %}

--- a/fundamentals/points.md
+++ b/fundamentals/points.md
@@ -31,75 +31,76 @@ viewer.add_points(points, size=30)
 
 Both `view_points` and `add_points` have the following doc strings:
 
-```
+```python
+"""
 Parameters
-    ----------
-    data : array (N, D)
-        Coordinates for N points in D dimensions.
-    properties : dict {str: array (N,)}, DataFrame
-        Properties for each point. Each property should be an array of length N,
-        where N is the number of points.
-    symbol : str
-        Symbol to be used for the point markers. Must be one of the
-        following: arrow, clobber, cross, diamond, disc, hbar, ring,
-        square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
-    size : float, array
-        Size of the point marker. If given as a scalar, all points are made
-        the same size. If given as an array, size must be the same
-        broadcastable to the same shape as the data.
-    edge_width : float
-        Width of the symbol edge in pixels.
-    edge_color : str, array-like
-        Color of the point marker border. Numeric color values should be RGB(A).
-    edge_color_cycle : np.ndarray, list
-        Cycle of colors (provided as string name, RGB, or RGBA) to map to edge_color if a
-        categorical attribute is used color the vectors.
-    edge_colormap : str, vispy.color.colormap.Colormap
-        Colormap to set edge_color if a continuous attribute is used to set face_color.
-        See vispy docs for details: http://vispy.org/color.html#vispy.color.Colormap
-    edge_contrast_limits : None, (float, float)
-        clims for mapping the property to a color map. These are the min and max value
-        of the specified property that are mapped to 0 and 1, respectively.
-        The default value is None. If set the none, the clims will be set to
-        (property.min(), property.max())
-    face_color : str, array-like
-        Color of the point marker body. Numeric color values should be RGB(A).
-    face_color_cycle : np.ndarray, list
-        Cycle of colors (provided as string name, RGB, or RGBA) to map to face_color if a
-        categorical attribute is used color the vectors.
-    face_colormap : str, vispy.color.colormap.Colormap
-        Colormap to set face_color if a continuous attribute is used to set face_color.
-        See vispy docs for details: http://vispy.org/color.html#vispy.color.Colormap
-    face_contrast_limits : None, (float, float)
-        clims for mapping the property to a color map. These are the min and max value
-        of the specified property that are mapped to 0 and 1, respectively.
-        The default value is None. If set the none, the clims will be set to
-        (property.min(), property.max())
-    n_dimensional : bool
-        If True, renders points not just in central plane but also in all
-        n-dimensions according to specified point marker size.
-    name : str
-        Name of the layer.
-    metadata : dict
-        Layer metadata.
-    scale : tuple of float
-        Scale factors for the layer.
-    translate : tuple of float
-        Translation values for the layer.
-    opacity : float
-        Opacity of the layer visual, between 0.0 and 1.0.
-    blending : str
-        One of a list of preset blending modes that determines how RGB and
-        alpha values of the layer visual get mixed. Allowed values are
-        {'opaque', 'translucent', and 'additive'}.
-    visible : bool
-        Whether the layer visual is currently being displayed.
+----------
+data : array (N, D)
+    Coordinates for N points in D dimensions.
+properties : dict {str: array (N,)}, DataFrame
+    Properties for each point. Each property should be an array of length N,
+    where N is the number of points.
+symbol : str
+    Symbol to be used for the point markers. Must be one of the
+    following: arrow, clobber, cross, diamond, disc, hbar, ring,
+    square, star, tailed_arrow, triangle_down, triangle_up, vbar, x.
+size : float, array
+    Size of the point marker. If given as a scalar, all points are made
+    the same size. If given as an array, size must be the same
+    broadcastable to the same shape as the data.
+edge_width : float
+    Width of the symbol edge in pixels.
+edge_color : str, array-like
+    Color of the point marker border. Numeric color values should be RGB(A).
+edge_color_cycle : np.ndarray, list
+    Cycle of colors (provided as string name, RGB, or RGBA) to map to edge_color if a
+    categorical attribute is used color the vectors.
+edge_colormap : str, vispy.color.colormap.Colormap
+    Colormap to set edge_color if a continuous attribute is used to set face_color.
+    See vispy docs for details: http://vispy.org/color.html#vispy.color.Colormap
+edge_contrast_limits : None, (float, float)
+    clims for mapping the property to a color map. These are the min and max value
+    of the specified property that are mapped to 0 and 1, respectively.
+    The default value is None. If set the none, the clims will be set to
+    (property.min(), property.max())
+face_color : str, array-like
+    Color of the point marker body. Numeric color values should be RGB(A).
+face_color_cycle : np.ndarray, list
+    Cycle of colors (provided as string name, RGB, or RGBA) to map to face_color if a
+    categorical attribute is used color the vectors.
+face_colormap : str, vispy.color.colormap.Colormap
+    Colormap to set face_color if a continuous attribute is used to set face_color.
+    See vispy docs for details: http://vispy.org/color.html#vispy.color.Colormap
+face_contrast_limits : None, (float, float)
+    clims for mapping the property to a color map. These are the min and max value
+    of the specified property that are mapped to 0 and 1, respectively.
+    The default value is None. If set the none, the clims will be set to
+    (property.min(), property.max())
+n_dimensional : bool
+    If True, renders points not just in central plane but also in all
+    n-dimensions according to specified point marker size.
+name : str
+    Name of the layer.
+metadata : dict
+    Layer metadata.
+scale : tuple of float
+    Scale factors for the layer.
+translate : tuple of float
+    Translation values for the layer.
+opacity : float
+    Opacity of the layer visual, between 0.0 and 1.0.
+blending : str
+    One of a list of preset blending modes that determines how RGB and
+    alpha values of the layer visual get mixed. Allowed values are
+    {'opaque', 'translucent', and 'additive'}.
+visible : bool
+    Whether the layer visual is currently being displayed.
 
 Returns
 -------
 layer : napari.layers.Points
     The newly-created points layer.
-
+"""
 ```
 
 ## points data
@@ -107,6 +108,7 @@ layer : napari.layers.Points
 The input data to the points layer must be an NxD numpy array containing the coordinates of N points in D dimensions. The ordering of these dimensions is the same as the ordering of the dimensions for image layers. This array is always accessible through the `layer.data` property and will grow or shrink as new points are either added or deleted.
 
 ## using the points properties dictionary
+
 The `Points` layer can contain properties that annotate each point. `Points.properties` stores the properties in a dictionary where each key is the name of the property and the values are numpy arrays with a value for each point (i.e., length N for N points in `Points.data`). As we will see below, we can use the values in a property to set the display properties of the points (e.g., face color or edge color). To see the points properties in action, please see the [point annotation tutorial](../applications/annotate_points).
 
 ## creating a new points layer
@@ -150,11 +152,13 @@ Each point can have a different size. You can pass a list or 1-dimensional array
 Points can also be resized within the GUI by first selecting them and then adjusting the point size slider. If no points are selected then adjusting the slider value will only serve to initialize the size for new points that are about to be added. The value of the size of the next point to be added can be found in the `layer.size` property. Note this property is different from `layer.sizes` which contains the current sizes of all the points.
 
 ## changing points edge and face color
+
 Individual points can each have different edge and face colors. You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively, or you can edit them from the GUI. The colors of each of the points are available as lists under the `layer.edge_colors` and `layer.face_colors` properties. Similar to the `sizes` and `size` properties these properties are different from the `layer.edge_color` and `layer.face_color` properties that will determine the color of the next point to be added or any currently selected points.
 
 To change the point color properties from the GUI you must first select the points whose properties you want to change, otherwise you will just be initializing the property for the next point you add.
 
 ## setting point edge and face color with properties
+
 Point edge and face colors can be set as a function of a property in `Points.properties`. There are two ways that the values in properties can be mapped to colors: (1) color cycles and (2) colormaps.
 
 Color cycles are sets of colors that are mapped to categorical properties. The colors are repeated if the number of unique property values is greater than the number of colors in the color cycle.
@@ -183,6 +187,7 @@ Colormaps are a continuum of colors that are mapped to a continuous property val
 * RdBu
 
 ### setting edge or face color with a color cycle
+
 Here we will set the edge color of the markers with a color cycle on a property. To do the same for a face color, substitute `face_color` for `edge_color` in the example snippet below.
 
 ```python
@@ -205,11 +210,13 @@ with napari.gui_qt():
         edge_width=5,
     )
 ```
+
 ![image]({{ '/assets/tutorials/points_edge_color_cycle.png' | relative_url }})
 
 In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`. The values of each property is stored in a numpy ndarray with length 3 since there were three coordinates provided in `points`. We set the edge color as a function of the `good_point` property by providing the keyword argument `edge_color='good_point'` to the `viewer.add_points()` method. We set the color cycle via the `edge_color_cycle` keyword argument (`edge_color_cycle=['magenta', 'green']`). The color cycle can be provided as a list of colors (a list of strings or a (M x 4) array of M RGBA colors).
 
 ### setting edge or face color with a colormap
+
 Here we will set the face color of the markers with a color cycle on a property. To do the same for a face color, substitute `edge_color` for `face_color` in the example snippet below.
 
 ```python
@@ -231,12 +238,13 @@ with napari.gui_qt():
         face_colormap='viridis',
     )
 ```
+
 ![image]({{ '/assets/tutorials/points_face_colormap.png' | relative_url }})
 
 In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`. The values of each property is stored in a numpy ndarray with length 3 since there were three coordinates provided in `points`. We set the face color as a function of the `confidence` property by providing the keyword argument `face_color='confidence'` to the `viewer.add_points()` method. We set the colormap to viridis using the `face_colormap` keyword argument (`face_colormap='viridis'`).
 
-
 ## changing the points symbol
+
 The symbol for the points layer is a global property for the layer. All points must have the same symbol. You can set the symbol on the loading of the layer using the `symbol` keyword argument, or you can change it from the the GUI using the symbol dropdown menu. Since the symbol property applies to all the points you don't need to have any points selected for it to have an effect.
 
 ## copying and pasting points

--- a/fundamentals/points.md
+++ b/fundamentals/points.md
@@ -21,7 +21,7 @@ At the end of the tutorial you should understand how to add a points layer
 and edit it from the GUI and from the console.
 
 The points layer allows you to display an NxD array of N points in D coordinates.
-You can adjust the size, face color, edge color of all of the points independently.
+You can adjust the size, face color, and edge color of all the points independently.
 You can also adjust the opactiy, edge width, and symbol representing all the points simultaneously.
 
 Each data point can have annotations associated with it using the `Points.properties` dictionary.
@@ -168,7 +168,7 @@ As note in the section on 3D rendering, when using 3D rendering the points layer
 
 All our layers can be rendered in both 2D and 3D mode,
 and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer.
 See for example these points overlaid on an image in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/smFISH.gif' | relative_url }})
@@ -180,7 +180,7 @@ Those options are only supported when viewing a layer using 2D rendering.
 ## pan and zoom mode
 
 The default mode of the points layer is to support panning and zooming, as in the image layer.
-This mode is represent by the magnifying glass in the layers control panel,
+This mode is represented by the magnifying glass in the layers control panel,
 and while it is selected editing the layer is not possible.
 Continue reading to learn how to use some of the editing modes.
 You can always return to pan and zoom mode by pressing the `Z` key when the points layer is selected.
@@ -220,10 +220,10 @@ or the `n-dimensional` checkbox is checked.
 In this setting when viewing different slices of the layer
 points will appear in the neighbouring slices to the ones in which they are located
 with a size scaled by the distance from their center to that slice.
-This feature can be very useful when visualizing 2D slices of points that are located in a 3D volume.
+This feature can be especially useful when visualizing 2D slices of points that are located in a 3D volume.
 
 Points can also be resized within the GUI by first selecting them and then adjusting the point size slider.
-If no points are selected then adjusting the slider value will only serve to initialize the size for new points that are about to be added.
+If no points are selected, then adjusting the slider value will only serve to initialize the size for new points that are about to be added.
 The value of the size of the next point to be added can be found in the `layer.size` property.
 Note this property is different from `layer.sizes` which contains the current sizes of all the points.
 
@@ -303,7 +303,7 @@ with napari.gui_qt():
 ![image]({{ '/assets/tutorials/points_edge_color_cycle.png' | relative_url }})
 
 In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`.
-The values of each property is stored in a numpy ndarray with length 3
+The values of each property are stored in a numpy ndarray with length 3
 since there were three coordinates provided in `points`.
 We set the edge color as a function of the `good_point` property
 by providing the keyword argument `edge_color='good_point'` to the `viewer.add_points()` method.
@@ -338,7 +338,7 @@ with napari.gui_qt():
 ![image]({{ '/assets/tutorials/points_face_colormap.png' | relative_url }})
 
 In the example above, the properties (`point_properties`) were provided as a dictionary with two properties: `good_point` and `confidence`.
-The values of each property is stored in a numpy ndarray with length 3
+The values of each property are stored in a numpy ndarray with length 3
 since there were three coordinates provided in `points`.
 We set the face color as a function of the `confidence` property
 by providing the keyword argument `face_color='confidence'` to the `viewer.add_points()` method.
@@ -355,8 +355,8 @@ you don't need to have any points selected for it to have an effect.
 
 ## copying and pasting points
 
-It is possible to copy and paste any selected points using the `ctrl-C` and `ctrl-V` keybindings respectively.
-If you have a multidimensional points layer you can copy points from one slice to another by pasting them into the new slice.
+It is possible to copy and paste any selected points using the `ctrl-C` and `ctrl-V` keybindings, respectively.
+If you have a multidimensional `Points` layer you can copy points from one slice to another by pasting them into the new slice.
 The coordinates of the points in the visible dimensions will be in the same place on the new slice as in the old slice,
 but the rest of the coordinates will be updated with the new slice values.
 
@@ -377,15 +377,15 @@ and so you don't need to have any points selected for it to have an effect.
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
-This mode is very useful for visualizing multiple layers at the same time.
+This mode is especially useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
@@ -419,7 +419,7 @@ Here you can see an example of adding, selecting, deleting points and change the
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Points` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Points` layer,
 including how to create one and control its properties.
 To learn more about some of the other layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/shapes.md
+++ b/fundamentals/shapes.md
@@ -46,7 +46,8 @@ with napari.gui_qt():
 
 Both `view_shapes` and `add_shapes` have the following doc strings:
 
-```
+```python
+"""
 Parameters
 ----------
 data : np.array | list
@@ -94,6 +95,7 @@ Returns
 -------
 layer : napari.layers.Shapes
     The newly-created shapes layer.
+"""
 ```
 
 ## shapes data
@@ -175,11 +177,13 @@ For example see below:
 ![image]({{ '/assets/tutorials/shape_vertex_editing.gif' | relative_url }})
 
 ## changing shape edge and face colors
+
 Individual shapes can each have different edge and face colors. You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively, or you can edit them from the GUI. The colors of each of the shapes are available as lists under the `layer.edge_colors` and `layer.face_colors` properties. These properties are different from the `layer.edge_color` and `layer.face_color` properties that will determine the color of the next shape to be added or any currently selected shapes.
 
 To change the shape color properties from the GUI you must first select the shape whose properties you want to change, otherwise you will just be initializing the property for the next shape you add.
 
 ## changing shape edge widths
+
 Individual shapes can each have different edge widths. You can initially set the edge widths by providing a list of values to the `edge_width` keyword arguments respectively, or you can edit them from the GUI. The widths of each of the shapes are available as a lists under the `layer.edge_widths` property. Similar to the edge and face colors, these property is different from the `layer.edge_width` property that will determine the edge width of the next shape to be added or any currently selected shapes.
 
 To change the edge with property from the GUI you must first select the shape whose properties you want to change, otherwise you will just be initializing the property for the next shape you add.

--- a/fundamentals/shapes.md
+++ b/fundamentals/shapes.md
@@ -2,15 +2,32 @@
 
 Welcome to the tutorial on the **napari** `Shapes` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**,
+know how to launch the viewer,
+and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Shapes` layer, including how to display and edit shapes like rectangle, ellipses, polygons, paths, and lines. At the end of the tutorial you should understand how to add a shapes layer and edit it from the GUI and from the console.
+This tutorial will teach you about the **napari** `Shapes` layer,
+including how to display and edit shapes like rectangle, ellipses, polygons, paths, and lines.
+At the end of the tutorial you should understand how to add a shapes layer
+and edit it from the GUI and from the console.
 
-The points layer allows you to display a list of an NxD arrays, where each array corresponds to one shape, specified by N points in D coordinates. You can adjust the position, size, face color, edge color, and opacity of all the shapes independently, both programmatically and from the GUI.
+The points layer allows you to display a list of an NxD arrays,
+where each array corresponds to one shape, specified by N points in D coordinates.
+You can adjust the position, size, face color, edge color, and opacity of all the shapes independently, both programmatically and from the GUI.
 
 ## a simple example
 
-You can create a new viewer and add a list of shapes in one go using the `napari.view_shapes` method, or if you already have an existing viewer, you can add shapes to it using `viewer.add_shapes`. The api of both methods is the same. In these examples we'll mainly use `add_shapes` to overlay shapes onto on an existing image.
+You can create a new viewer and add a list of shapes in one go using the `napari.view_shapes` method,
+or if you already have an existing viewer, you can add shapes to it using `viewer.add_shapes`.
+The api of both methods is the same.
+In these examples we'll mainly use `add_shapes` to overlay shapes onto on an existing image.
 
 In this example of we will overlay some shapes on the image of a photographer:
 
@@ -100,63 +117,156 @@ layer : napari.layers.Shapes
 
 ## shapes data
 
-The input data to the shapes layer must be a list of NxD numpy array, with each array containing the coordinates of the N vertices in D dimensions that make up the shape. The ordering of these dimensions is the same as the ordering of the dimensions for image layers. This list of arrays array is always accessible through the `layer.data` property and will grow or shrink as new shapes are either added or deleted. By storing data as a list of arrays it is possible for each shape to have a different number of vertices in it. This is very useful when drawing polygons or paths.
+The input data to the shapes layer must be a list of NxD numpy array,
+with each array containing the coordinates of the N vertices in D dimensions that make up the shape.
+The ordering of these dimensions is the same as the ordering of the dimensions for image layers.
+This list of arrays array is always accessible through the `layer.data` property
+and will grow or shrink as new shapes are either added or deleted.
+By storing data as a list of arrays
+it is possible for each shape to have a different number of vertices in it.
+This is very useful when drawing polygons or paths.
 
 ## adding different shape types
 
-Right now the shapes layer supports 5 types of shapes, `Lines`, `Rectangles`, `Ellipses`, `Polygons`, and `Paths`. When adding new data can set the shape type through the `shape_type` keyword argument, as either a single shape type if all the shapes to be added have the same type or as a list of shape types if some of the shapes have different types. The actual shape types of all the shapes is accessible through the `layer.shape_types` property. Selecting different shape creation tools will cause shapes of the different types to be added.
+Right now the shapes layer supports 5 types of shapes,
+`Lines`, `Rectangles`, `Ellipses`, `Polygons`, and `Paths`.
+When adding new data can set the shape type through the `shape_type` keyword argument,
+as either a single shape type if all the shapes to be added have the same type
+or as a list of shape types if some of the shapes have different types.
+The actual shape types of all the shapes is accessible through the `layer.shape_types` property.
+Selecting different shape creation tools will cause shapes of the different types to be added.
 
-`Lines` consist of two vertices representing the end points of the line. The line creation tool can be selected from the layer control panel or by pressing the `L` key when the shapes layer is selected. When adding a new line the first click will coordinates of the first endpoint and the second click will mark the coordinates of the second endpoint. You'll then be able to add another line.
+`Lines` consist of two vertices representing the end points of the line.
+The line creation tool can be selected from the layer control panel
+or by pressing the `L` key when the shapes layer is selected.
+When adding a new line
+the first click will coordinates of the first endpoint
+and the second click will mark the coordinates of the second endpoint.
+You'll then be able to add another line.
 
-`Rectangles` can be added using two vertices representing the corners of the rectangle for axis aligned rectangle, or using four corners so that non-axis aligned rectangle can be represented too. Internally we use the four vertex representation so we can always support rotated rectangles. The rectangle creation tool can be selected from the layer control panel or by pressing the `R` key when the shapes layer is selected. When adding a rectangle you must click and drag the rectangle to have the desired shape. When you release the mouse the rectangle will be completed and you'll then be able to add another one. If you just make a single click then a rectangle of default size will be created centered on that click.
+`Rectangles` can be added using two vertices representing the corners of the rectangle for axis aligned rectangle,
+or using four corners so that non-axis aligned rectangle can be represented too.
+Internally we use the four vertex representation so we can always support rotated rectangles.
+The rectangle creation tool can be selected from the layer control panel
+or by pressing the `R` key when the shapes layer is selected.
+When adding a rectangle you must click and drag the rectangle to have the desired shape.
+When you release the mouse the rectangle will be completed
+and you'll then be able to add another one.
+If you just make a single click
+then a rectangle of default size will be created centered on that click.
 
-`Ellipses` can be added using either two vectors, one representing the center position of the ellipse and the other representing the radii of the ellipse in all dimensions for an axis aligned ellipse, or by using the four corners of the ellipse bounding box for a non-axis aligned ellipse. Internally we use the four vertex representation so we can always support rotated ellipses. The ellipse creation tool can be selected from the layer control panel or by pressing the `E` key when the shapes layer is selected. When adding an ellipse you must click and drag the ellipse to have the desired shape. When you release the mouse the ellipse will be completed and you'll then be able to add another one. If you just make a single click then an ellipse of default size will be created centered on that click.
+`Ellipses` can be added using either two vectors,
+one representing the center position of the ellipse
+and the other representing the radii of the ellipse in all dimensions for an axis aligned ellipse,
+or by using the four corners of the ellipse bounding box for a non-axis aligned ellipse.
+Internally we use the four vertex representation so we can always support rotated ellipses.
+The ellipse creation tool can be selected from the layer control panel
+or by pressing the `E` key when the shapes layer is selected.
+When adding an ellipse you must click and drag the ellipse to have the desired shape.
+When you release the mouse
+the ellipse will be completed
+and you'll then be able to add another one.
+If you just make a single click
+then an ellipse of default size will be created centered on that click.
 
-`Polygons` can be added using an array of N vertices. Polygons are closed by default, and so you don't also need to include the first point at the end of the array. The order of the vertices will determine the triangulation of the polygon, which can be non-convex, but cannot have holes. The polygon creation tool can be selected from the layer control panel or by pressing the `P` key when the shapes layer is selected. When adding a polygon each click will add a vertex at the clicked location. To finish drawing a polygon you must click the `escape` key, which will add a final vertex at the current mouse position and complete the polygon.  You'll then be able to start adding another one.
+`Polygons` can be added using an array of N vertices.
+Polygons are closed by default,
+and so you don't also need to include the first point at the end of the array.
+The order of the vertices will determine the triangulation of the polygon,
+which can be non-convex, but cannot have holes.
+The polygon creation tool can be selected from the layer control panel
+or by pressing the `P` key when the shapes layer is selected.
+When adding a polygon
+each click will add a vertex at the clicked location.
+To finish drawing a polygon you must click the `escape` key,
+which will add a final vertex at the current mouse position and complete the polygon.
+You'll then be able to start adding another one.
 
-`Paths` are very similar to polygons but are not closed or filled in. They can also be added using an array of N vertices. The path creation tool can be selected from the layer control panel or by pressing the `T` key when the shapes layer is selected. When adding a path each click will add a vertex at the clicked location. To finish drawing a path you must click the `escape` key, which will add a final vertex at the current mouse position and complete the path.  You'll then be able to start adding another one.
+`Paths` are very similar to polygons but are not closed or filled in.
+They can also be added using an array of N vertices.
+The path creation tool can be selected from the layer control panel
+or by pressing the `T` key when the shapes layer is selected.
+When adding a path each click will add a vertex at the clicked location.
+To finish drawing a path you must click the `escape` key,
+which will add a final vertex at the current mouse position and complete the path.
+You'll then be able to start adding another one.
 
-When using the shapes addition or editing tools the pan and zoom functionality of the viewer canvas is disabled and you are able to edit the layer. You can temporarily re-enable pan and zoom by pressing and holding the spacebar. This feature can be useful if you want to move around the shapes layer as you edit it.
+When using the shapes addition or editing tools
+the pan and zoom functionality of the viewer canvas is disabled and you are able to edit the layer.
+You can temporarily re-enable pan and zoom
+by pressing and holding the spacebar.
+This feature can be useful if you want to move around the shapes layer as you edit it.
 
 ## creating a new shapes layer
 
-As you can add new shapes to a shapes layer using the various shape creation tools, it is possible to create a brand new empty shapes layers by clicking the new shapes layer button above the layers list. The shape of the shapes layer is defined by the shapes inside it, and so as you add new shapes the shape will adjust as needed. The dimension of the new shapes layer will default to the largest dimension of any layer currently in the viewer, or to 2 if no other layers are present in the viewer.
+As you can add new shapes to a shapes layer using the various shape creation tools,
+it is possible to create a brand new empty shapes layers
+by clicking the new shapes layer button above the layers list.
+The shape of the shapes layer is defined by the shapes inside it,
+and so as you add new shapes the shape will adjust as needed.
+The dimension of the new shapes layer will default to the largest dimension of any layer currently in the viewer,
+or to 2 if no other layers are present in the viewer.
 
 ## non-editable mode
 
-If you want to disable editing of the shapes layer you can set the `editable` property of the layer to `False`.
+If you want to disable editing of the shapes layer
+you can set the `editable` property of the layer to `False`.
 
-As note in the section on 3D rendering, when using 3D rendering the shapes layer is not editable.
+As note in the section on 3D rendering,
+when using 3D rendering the shapes layer is not editable.
 
 ## 3D rendering of shapes
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer. See for example the `examples/nD_shapes.py` to see shapes in both 2D and 3D:
+All our layers can be rendered in both 2D and 3D mode,
+and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+See for example the `examples/nD_shapes.py` to see shapes in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/nD_shapes.gif' | relative_url }})
 
-Note though that when entering 3D rendering mode the shape editing tools are all disabled. Those options are only supported when viewing a layer using 2D rendering.
+Note though that when entering 3D rendering mode
+the shape editing tools are all disabled.
+Those options are only supported when viewing a layer using 2D rendering.
 
-Note also that for a multidimensional shape to be displayed on a given view slice all of it's non-displayed coordinates must match the coordinates of that view slice, i.e. the shape must be entirely defined within that plane.
+Note also that for a multidimensional shape to be displayed on a given view slice
+all of it's non-displayed coordinates must match the coordinates of that view slice,
+i.e. the shape must be entirely defined within that plane.
 
-For paths that are defined by coordinates spanning more than two dimensions, it is possible to visualize them as 3D cylinders, see for example the `examples/3D_paths.py`
+For paths that are defined by coordinates spanning more than two dimensions,
+it is possible to visualize them as 3D cylinders, see for example the `examples/3D_paths.py`
 
 ![image]({{ '/assets/tutorials/3D_paths.png' | relative_url }})
 
-Right now it is not possible to display 3D cuboids or 3D spheroids, but will be supporting those options soon.
+Right now it is not possible to display 3D cuboids or 3D spheroids,
+but will be supporting those options soon.
 
 ## pan and zoom mode
 
-The default mode of the shapes layer is to support panning and zooming, as in the image layer. This mode is represent by the magnifying glass in the layers control panel, and while it is selected editing the layer is not possible. Continue reading to learn how to use some of the editing modes. You can always return to pan and zoom mode by pressing the `Z` key when the shapes layer is selected.
+The default mode of the shapes layer is to support panning and zooming, as in the image layer.
+This mode is represent by the magnifying glass in the layers control panel,
+and while it is selected editing the layer is not possible.
+Continue reading to learn how to use some of the editing modes.
+You can always return to pan and zoom mode by pressing the `Z` key
+when the shapes layer is selected.
 
 ## selecting, resizing, moving, and deleting shapes
 
-New shapes can be added using one of the 5 shape creation tools, for `Lines`, `Rectangles`, `Ellipses`, `Polygons`, and `Paths`. For more information on the different shape types see the shape types section.
+New shapes can be added using one of the 5 shape creation tools,
+for `Lines`, `Rectangles`, `Ellipses`, `Polygons`, and `Paths`.
+For more information on the different shape types see the shape types section.
 
-You can select a shape by clicking on it using the shape selection tool, which can be selected by clicking on it in the layer controls panel or by pressing the `S` key when the shapes layer is selected. Once selected you can move the shape by dragging it. You can also resize the shape by clicking and dragging on one of the handles along the edge of the shape bounding box. You can also rotate the shape by clicking and dragging on the rotation handle above the shape bounding box.
+You can select a shape by clicking on it using the shape selection tool,
+which can be selected by clicking on it in the layer controls panel
+or by pressing the `S` key when the shapes layer is selected.
+Once selected you can move the shape by dragging it.
+You can also resize the shape by clicking and dragging on one of the handles along the edge of the shape bounding box.
+You can also rotate the shape by clicking and dragging on the rotation handle above the shape bounding box.
 
-When resizing a layer if you hold down the `shift` key the aspect ratio of the shape will lock and you can continue to resize the shape now with a fixed aspect ratio.
+When resizing a layer if you hold down the `shift` key
+the aspect ratio of the shape will lock and you can continue to resize the shape now with a fixed aspect ratio.
 
-You can select multiple shapes by continuing to shift click on additional shapes after the first, or by dragging a bounding box around the shapes you want to select.
+You can select multiple shapes by continuing to shift click on additional shapes after the first,
+or by dragging a bounding box around the shapes you want to select.
 
 You can select all the shapes in the currently viewed slice by clicking the `A` key if you are in select mode.
 
@@ -167,70 +277,121 @@ For example see below:
 
 ## adding, moving, and deleting individual vertices
 
-You can move individual vertices by entering the direct selection mode by either clicking on the direct select tool in the layer controls panel or pressing the `D` key while the shapes layer is selected. To move a vertex you can click and drag it to its new position.
+You can move individual vertices by entering the direct selection mode
+by either clicking on the direct select tool in the layer controls panel
+or pressing the `D` key while the shapes layer is selected.
+To move a vertex you can click and drag it to its new position.
 
-You can add vertices to a selected shape using the vertex addition tool which can be selected either clicking on the vertex addition tool in the layer controls panel or pressing the `I` key while the shapes layer is selected.
+You can add vertices to a selected shape using the vertex addition tool
+which can be selected either clicking on the vertex addition tool in the layer controls panel
+or pressing the `I` key while the shapes layer is selected.
 
-You can delete vertices to a selected shape using the vertex deletion tool which can be selected either clicking on the vertex deletion tool in the layer controls panel or pressing the `X` key while the shapes layer is selected.
+You can delete vertices to a selected shape using the vertex deletion tool
+which can be selected either clicking on the vertex deletion tool in the layer controls panel
+or pressing the `X` key while the shapes layer is selected.
 
 For example see below:
 ![image]({{ '/assets/tutorials/shape_vertex_editing.gif' | relative_url }})
 
 ## changing shape edge and face colors
 
-Individual shapes can each have different edge and face colors. You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively, or you can edit them from the GUI. The colors of each of the shapes are available as lists under the `layer.edge_colors` and `layer.face_colors` properties. These properties are different from the `layer.edge_color` and `layer.face_color` properties that will determine the color of the next shape to be added or any currently selected shapes.
+Individual shapes can each have different edge and face colors.
+You can initially set these colors by providing a list of colors to the `edge_color` or `face_color` keyword arguments respectively,
+or you can edit them from the GUI.
+The colors of each of the shapes are available as lists under the `layer.edge_colors` and `layer.face_colors` properties.
+These properties are different from the `layer.edge_color` and `layer.face_color` properties
+that will determine the color of the next shape to be added or any currently selected shapes.
 
-To change the shape color properties from the GUI you must first select the shape whose properties you want to change, otherwise you will just be initializing the property for the next shape you add.
+To change the shape color properties from the GUI
+you must first select the shape whose properties you want to change,
+otherwise you will just be initializing the property for the next shape you add.
 
 ## changing shape edge widths
 
-Individual shapes can each have different edge widths. You can initially set the edge widths by providing a list of values to the `edge_width` keyword arguments respectively, or you can edit them from the GUI. The widths of each of the shapes are available as a lists under the `layer.edge_widths` property. Similar to the edge and face colors, these property is different from the `layer.edge_width` property that will determine the edge width of the next shape to be added or any currently selected shapes.
+Individual shapes can each have different edge widths.
+You can initially set the edge widths by providing a list of values to the `edge_width` keyword arguments respectively,
+or you can edit them from the GUI.
+The widths of each of the shapes are available as a lists under the `layer.edge_widths` property.
+Similar to the edge and face colors, these property is different from the `layer.edge_width` property
+that will determine the edge width of the next shape to be added or any currently selected shapes.
 
-To change the edge with property from the GUI you must first select the shape whose properties you want to change, otherwise you will just be initializing the property for the next shape you add.
+To change the edge with property from the GUI
+you must first select the shape whose properties you want to change,
+otherwise you will just be initializing the property for the next shape you add.
 
 ## layer ordering
 
-You can adjust the ordering of shapes in the layer by selecting shapes and then clicking the move to front or move to back buttons. You can get the ordering of all the shapes using the `layer.z_indices` property. You can also set the initial ordering of shapes by passing a list to the `layer.z_index` property.
+You can adjust the ordering of shapes in the layer
+by selecting shapes and then clicking the move to front or move to back buttons.
+You can get the ordering of all the shapes using the `layer.z_indices` property.
+You can also set the initial ordering of shapes by passing a list to the `layer.z_index` property.
 
 ## copying and pasting shapes
 
-It is possible to copy and paste any selected shapes using the `ctrl-C` and `ctrl-V` keybindings respectively. If you have a multidimensional shapes layer you can copy shapes from one slice to another by pasting them into the new slice. The coordinates of the shapes in the visible dimensions will be in the same place on the new slice as in the old slice, but the rest of the coordinates will be updated with the new slice values.
+It is possible to copy and paste any selected shapes using the `ctrl-C` and `ctrl-V` keybindings respectively.
+If you have a multidimensional shapes layer you can copy shapes from one slice to another
+by pasting them into the new slice.
+The coordinates of the shapes in the visible dimensions will be in the same place on the new slice as in the old slice,
+but the rest of the coordinates will be updated with the new slice values.
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible. The opacity value applies individually to each shape in the layer, and so you must have shapes selected for it to have an effect.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+The opacity value applies individually to each shape in the layer,
+and so you must have shapes selected for it to have an effect.
 
-You can also initialize the shape opacities using the `opacity` keyword argument which accepts either a list of opacities or a single opacity value that will be applied globally. You can then access the opacity of every shape using the `layer.opacities` property. Note that this property is different from the `layer.opacity` property that determines the opacity of the next shape to be added.
+You can also initialize the shape opacities using the `opacity` keyword argument
+which accepts either a list of opacities or a single opacity value that will be applied globally.
+You can then access the opacity of every shape using the `layer.opacities` property.
+Note that this property is different from the `layer.opacity` property
+that determines the opacity of the next shape to be added.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for visualizing multiple layers at the same time.
+The final blending mode `additive` will cause the layer to blend with the layers below
+even when it has full opacity.
+This mode is very useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property
+that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic data where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument
+that will rescale the layer multiplicatively according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic data
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## putting it all together
 
@@ -240,6 +401,10 @@ Here you can see an example of adding, selecting, and editing shapes and change 
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Shapes` layer, including how to create one and control its properties. To learn more about some of the other layer types that **napari** supports checkout some more of our tutorials listed below. The [surface layer](./surface) tutorial is a great one to try next as it describes rendering complex surfaces.
+Hopefully this tutorial has given you a detailed understanding of the `Shapes` layer,
+including how to create one and control its properties.
+To learn more about some of the other layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [surface layer](./surface) tutorial is a great one to try next as it describes rendering complex surfaces.
 
 {% include footer.md %}

--- a/fundamentals/shapes.md
+++ b/fundamentals/shapes.md
@@ -120,11 +120,11 @@ layer : napari.layers.Shapes
 The input data to the shapes layer must be a list of NxD numpy array,
 with each array containing the coordinates of the N vertices in D dimensions that make up the shape.
 The ordering of these dimensions is the same as the ordering of the dimensions for image layers.
-This list of arrays array is always accessible through the `layer.data` property
+This list of arrays is always accessible through the `layer.data` property
 and will grow or shrink as new shapes are either added or deleted.
 By storing data as a list of arrays
 it is possible for each shape to have a different number of vertices in it.
-This is very useful when drawing polygons or paths.
+This is especially useful when drawing polygons or paths.
 
 ## adding different shape types
 
@@ -182,7 +182,7 @@ To finish drawing a polygon you must click the `escape` key,
 which will add a final vertex at the current mouse position and complete the polygon.
 You'll then be able to start adding another one.
 
-`Paths` are very similar to polygons but are not closed or filled in.
+`Paths` are like polygons but are not closed or filled in.
 They can also be added using an array of N vertices.
 The path creation tool can be selected from the layer control panel
 or by pressing the `T` key when the shapes layer is selected.
@@ -192,7 +192,7 @@ which will add a final vertex at the current mouse position and complete the pat
 You'll then be able to start adding another one.
 
 When using the shapes addition or editing tools
-the pan and zoom functionality of the viewer canvas is disabled and you are able to edit the layer.
+the pan and zoom functionality of the viewer canvas is disabled and you can edit the layer.
 You can temporarily re-enable pan and zoom
 by pressing and holding the spacebar.
 This feature can be useful if you want to move around the shapes layer as you edit it.
@@ -200,7 +200,7 @@ This feature can be useful if you want to move around the shapes layer as you ed
 ## creating a new shapes layer
 
 As you can add new shapes to a shapes layer using the various shape creation tools,
-it is possible to create a brand new empty shapes layers
+it is possible to create a brand-new empty shapes layers
 by clicking the new shapes layer button above the layers list.
 The shape of the shapes layer is defined by the shapes inside it,
 and so as you add new shapes the shape will adjust as needed.
@@ -219,7 +219,7 @@ when using 3D rendering the shapes layer is not editable.
 
 All our layers can be rendered in both 2D and 3D mode,
 and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer.
 See for example the `examples/nD_shapes.py` to see shapes in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/nD_shapes.gif' | relative_url }})
@@ -228,8 +228,8 @@ Note though that when entering 3D rendering mode
 the shape editing tools are all disabled.
 Those options are only supported when viewing a layer using 2D rendering.
 
-Note also that for a multidimensional shape to be displayed on a given view slice
-all of it's non-displayed coordinates must match the coordinates of that view slice,
+Also note that for a multidimensional shape to be displayed on a given view slice
+all of its non-displayed coordinates must match the coordinates of that view slice,
 i.e. the shape must be entirely defined within that plane.
 
 For paths that are defined by coordinates spanning more than two dimensions,
@@ -237,13 +237,13 @@ it is possible to visualize them as 3D cylinders, see for example the `examples/
 
 ![image]({{ '/assets/tutorials/3D_paths.png' | relative_url }})
 
-Right now it is not possible to display 3D cuboids or 3D spheroids,
+Right now, it is not possible to display 3D cuboids or 3D spheroids,
 but will be supporting those options soon.
 
 ## pan and zoom mode
 
 The default mode of the shapes layer is to support panning and zooming, as in the image layer.
-This mode is represent by the magnifying glass in the layers control panel,
+This mode is represented by the magnifying glass in the layers control panel,
 and while it is selected editing the layer is not possible.
 Continue reading to learn how to use some of the editing modes.
 You can always return to pan and zoom mode by pressing the `Z` key
@@ -280,7 +280,7 @@ For example see below:
 You can move individual vertices by entering the direct selection mode
 by either clicking on the direct select tool in the layer controls panel
 or pressing the `D` key while the shapes layer is selected.
-To move a vertex you can click and drag it to its new position.
+To move a vertex, you can click and drag it to its new position.
 
 You can add vertices to a selected shape using the vertex addition tool
 which can be selected either clicking on the vertex addition tool in the layer controls panel
@@ -311,7 +311,7 @@ otherwise you will just be initializing the property for the next shape you add.
 Individual shapes can each have different edge widths.
 You can initially set the edge widths by providing a list of values to the `edge_width` keyword arguments respectively,
 or you can edit them from the GUI.
-The widths of each of the shapes are available as a lists under the `layer.edge_widths` property.
+The widths of each of the shapes are available as a list under the `layer.edge_widths` property.
 Similar to the edge and face colors, these property is different from the `layer.edge_width` property
 that will determine the edge width of the next shape to be added or any currently selected shapes.
 
@@ -357,16 +357,16 @@ that determines the opacity of the next shape to be added.
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below
 even when it has full opacity.
-This mode is very useful for visualizing multiple layers at the same time.
+This mode is especially useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
@@ -401,7 +401,7 @@ Here you can see an example of adding, selecting, and editing shapes and change 
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Shapes` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Shapes` layer,
 including how to create one and control its properties.
 To learn more about some of the other layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/surface.md
+++ b/fundamentals/surface.md
@@ -2,15 +2,35 @@
 
 Welcome to the tutorial on the **napari** `Surface` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**,
+know how to launch the viewer,
+and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders
+see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Surface` layer, including how to diplay surface data and edit the properties of surfaces like the contrast, opacity, colormaps and blending mode. At the end of the tutorial you should understand how to add and manipulate surfaces both from the GUI and from the console.
+This tutorial will teach you about the **napari** `Surface` layer,
+including how to diplay surface data
+and edit the properties of surfaces like the contrast, opacity, colormaps and blending mode.
+At the end of the tutorial you should understand how to add and manipulate surfaces
+both from the GUI and from the console.
 
-The surface layer allows you to display precomputed a surface mesh that is defined by an NxD array of N vertices in D coordinates, an Mx3 integer array of the indices of the triangles making up the faces of the surface, and a length N list of values to associate with each vertex to use alongside a colormap.
+The surface layer allows you to display precomputed a surface mesh
+that is defined by an NxD array of N vertices in D coordinates,
+an Mx3 integer array of the indices of the triangles making up the faces of the surface,
+and a length N list of values to associate with each vertex to use alongside a colormap.
 
 ## a simple example
 
-You can create a new viewer and add a surface in one go using the `napari.view_surface` method, or if you already have an existing viewer, you can add an image to it using `viewer.add_surface`. The api of both methods is the same. In these examples we'll mainly use `view_surface`.
+You can create a new viewer and add a surface in one go using the `napari.view_surface` method,
+or if you already have an existing viewer, you can add an image to it using `viewer.add_surface`.
+The api of both methods is the same.
+In these examples we'll mainly use `view_surface`.
 
 A simple example of viewing a surface is as follows:
 
@@ -81,17 +101,27 @@ layer : napari.layers.Surface
 
 ## surface data
 
-The data for a surface layer is defined by a 3-tuple of its vertices, faces, and vertex values. The vertices are an NxD array of N vertices in D coordinates. The faces are an Mx3 integer array of the indices of the triangles making up the faces of the surface. The vertex values are a length N list of values to associate with each vertex to use alongside a colormap. This 3-tuple is accessible through the `layer.data` property.
+The data for a surface layer is defined by a 3-tuple of its vertices, faces, and vertex values.
+The vertices are an NxD array of N vertices in D coordinates.
+The faces are an Mx3 integer array of the indices of the triangles making up the faces of the surface.
+The vertex values are a length N list of values to associate with each vertex to use alongside a colormap.
+This 3-tuple is accessible through the `layer.data` property.
 
 ## 3D rendering of images
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer. See for example these brain surfaces rendered in 3D:
+All our layers can be rendered in both 2D and 3D mode,
+and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+See for example these brain surfaces rendered in 3D:
 
 ![image]({{ '/assets/tutorials/brain_surface.gif' | relative_url }})
 
 ## working with colormaps
 
-The same colormaps available for the `Image` layer are also available for the `Surface` layer. napari supports any colormap that is created with `vispy.color.Colormap`. We provide access to some standard colormaps that you can set using a string of their name. These include:
+The same colormaps available for the `Image` layer are also available for the `Surface` layer.
+napari supports any colormap that is created with `vispy.color.Colormap`.
+We provide access to some standard colormaps that you can set using a string of their name.
+These include:
 
 - PiYG
 - blue
@@ -111,50 +141,77 @@ The same colormaps available for the `Image` layer are also available for the `S
 - yellow
 - viridis
 
-Passing any of these as follows as keyword arguments will set the colormap of that surface. You can also access the current colormap through the `layer.colormap` property which returns a tuple of the colormap name followed by the vispy colormap object. You can list all the available colormaps using `layer.colormaps`.
+Passing any of these as follows as keyword arguments will set the colormap of that surface.
+You can also access the current colormap through the `layer.colormap` property
+which returns a tuple of the colormap name followed by the vispy colormap object.
+You can list all the available colormaps using `layer.colormaps`.
 
-It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object, see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap). For more detail see the [image layer tutorial](./image).
+It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object,
+see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap).
+For more detail see the [image layer tutorial](./image).
 
 ## adjusting contrast limits
 
-The vertex values of the surface layer gets mapped through its colormap according to values called contrast limits. These are a 2-tuple of values defining how what values get applied the minumum and maximum of the colormap and follow the same principles as the `contrast_limits` described in the [image layer tutorial](./image). They are also accessible through the same keyword arguments, properties, and range slider as in the image layer.
+The vertex values of the surface layer gets mapped through its colormap according to values called contrast limits.
+These are a 2-tuple of values defining how what values get applied the minumum and maximum of the colormap
+and follow the same principles as the `contrast_limits` described in the [image layer tutorial](./image).
+They are also accessible through the same keyword arguments, properties, and range slider as in the image layer.
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for visualizing multiple layers at the same time.
+The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
+This mode is very useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic data where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument
+that will rescale the layer multiplicatively according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic data
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer, including how to create one and control its properties. To learn more about some of the other layer types that **napari** supports checkout some more of our tutorials listed below. The [vectors layer](./vectors) tutorial is a great one to try next as it describes rendering lots of lines.
+Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer,
+including how to create one and control its properties.
+To learn more about some of the other layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [vectors layer](./vectors) tutorial is a great one to try next as it describes rendering lots of lines.
 
 {% include footer.md %}

--- a/fundamentals/surface.md
+++ b/fundamentals/surface.md
@@ -34,7 +34,7 @@ with napari.gui_qt():
 
 Both `view_surface` and `add_surface` have the following doc strings:
 
-```
+```python
 """
 
 Parameters
@@ -89,9 +89,10 @@ All our layers can be rendered in both 2D and 3D mode, and one of our viewer but
 
 ![image]({{ '/assets/tutorials/brain_surface.gif' | relative_url }})
 
-
 ## working with colormaps
+
 The same colormaps available for the `Image` layer are also available for the `Surface` layer. napari supports any colormap that is created with `vispy.color.Colormap`. We provide access to some standard colormaps that you can set using a string of their name. These include:
+
 - PiYG
 - blue
 - cyan
@@ -115,6 +116,7 @@ Passing any of these as follows as keyword arguments will set the colormap of th
 It is also possible to create your own colormaps using vispy's `vispy.color.Colormap` object, see it's full [documentation here](http://vispy.org/color.html#vispy.color.Colormap). For more detail see the [image layer tutorial](./image).
 
 ## adjusting contrast limits
+
 The vertex values of the surface layer gets mapped through its colormap according to values called contrast limits. These are a 2-tuple of values defining how what values get applied the minumum and maximum of the colormap and follow the same principles as the `contrast_limits` described in the [image layer tutorial](./image). They are also accessible through the same keyword arguments, properties, and range slider as in the image layer.
 
 ## layer visibility

--- a/fundamentals/surface.md
+++ b/fundamentals/surface.md
@@ -15,12 +15,12 @@ and the dimension sliders
 see our [napari viewer](./viewer) tutorial.
 
 This tutorial will teach you about the **napari** `Surface` layer,
-including how to diplay surface data
+including how to display surface data
 and edit the properties of surfaces like the contrast, opacity, colormaps and blending mode.
 At the end of the tutorial you should understand how to add and manipulate surfaces
 both from the GUI and from the console.
 
-The surface layer allows you to display precomputed a surface mesh
+The surface layer allows you to display a precomputed surface mesh
 that is defined by an NxD array of N vertices in D coordinates,
 an Mx3 integer array of the indices of the triangles making up the faces of the surface,
 and a length N list of values to associate with each vertex to use alongside a colormap.
@@ -111,7 +111,7 @@ This 3-tuple is accessible through the `layer.data` property.
 
 All our layers can be rendered in both 2D and 3D mode,
 and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer.
 See for example these brain surfaces rendered in 3D:
 
 ![image]({{ '/assets/tutorials/brain_surface.gif' | relative_url }})
@@ -152,8 +152,8 @@ For more detail see the [image layer tutorial](./image).
 
 ## adjusting contrast limits
 
-The vertex values of the surface layer gets mapped through its colormap according to values called contrast limits.
-These are a 2-tuple of values defining how what values get applied the minumum and maximum of the colormap
+The vertex values of the surface layer get mapped through its colormap according to values called contrast limits.
+These are a 2-tuple of values defining how what values get applied the minimum and maximum of the colormap
 and follow the same principles as the `contrast_limits` described in the [image layer tutorial](./image).
 They are also accessible through the same keyword arguments, properties, and range slider as in the image layer.
 
@@ -172,15 +172,15 @@ that allow you to adjust the layer opacity between 0, fully invisible, and 1, fu
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity.
-This mode is very useful for visualizing multiple layers at the same time.
+This mode is especially useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
@@ -208,7 +208,7 @@ that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Vectors` layer,
 including how to create one and control its properties.
 To learn more about some of the other layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/vectors.md
+++ b/fundamentals/vectors.md
@@ -2,15 +2,34 @@
 
 Welcome to the tutorial on the **napari** `Vectors` layer!
 
-This tutorial assumes you have already installed **napari**, know how to launch the viewer, and are familiar with its layout. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial. For help understanding the organisation of the viewer, including things like the layers list, the layer properties widgets, the layer control panels, and the dimension sliders see our [napari viewer](./viewer) tutorial.
+This tutorial assumes you have already installed **napari**,
+know how to launch the viewer,
+and are familiar with its layout.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+For help understanding the organisation of the viewer,
+including things like the layers list,
+the layer properties widgets,
+the layer control panels,
+and the dimension sliders
+see our [napari viewer](./viewer) tutorial.
 
-This tutorial will teach you about the **napari** `Vectors` layer, including how to display many vectors simultaneously and adjust their properties. At the end of the tutorial you should understand how to add a vectors layer and edit it from the GUI and from the console.
+This tutorial will teach you about the **napari** `Vectors` layer,
+including how to display many vectors simultaneously and adjust their properties.
+At the end of the tutorial you should understand how to add a vectors layer
+and edit it from the GUI and from the console.
 
-The vectors layer allows you to display a many vectors with defined starting points and directions. It is particularly useful for people who want to visualize large vector fields, for example if you are doing polarization microscopy. You can adjust the color, width, and length of all the vectors both programmatically and from the GUI.
+The vectors layer allows you to display a many vectors with defined starting points and directions.
+It is particularly useful for people who want to visualize large vector fields,
+for example if you are doing polarization microscopy.
+You can adjust the color, width, and length of all the vectors both programmatically and from the GUI.
 
 ## a simple example
 
-You can create a new viewer and add vectors in one go using the `napari.view_vectors` method, or if you already have an existing viewer, you can add shapes to it using `viewer.add_vectors`. The api of both methods is the same. In these examples we'll mainly use `add_vectors` to overlay shapes onto on an existing image.
+You can create a new viewer and add vectors in one go using the `napari.view_vectors` method,
+or if you already have an existing viewer, you can add shapes to it using `viewer.add_vectors`.
+The api of both methods is the same.
+In these examples we'll mainly use `add_vectors` to overlay shapes onto on an existing image.
 
 In this example of we will overlay some shapes on the image of a photographer:
 
@@ -73,19 +92,33 @@ layer : napari.layers.Vectors
 
 ## vectors data
 
-The input data to the vectors layer must either be a Nx2xD numpy array representing N vectors with start position and projection values in D dimensions, or it must be an N1xN2 ... xNDxD, array where each of the first D dimensions corresponds to the voxel of the location of the vector, and the last dimension contains the D values of the projection of that vector. The former representation is useful when you have vectors that can start in arbitrary positions in the canvas. The latter representation is useful when your vectors are defined on a grid, say corresponding to the voxels of an image, and you have one vector per grid.
+The input data to the vectors layer must either be a Nx2xD numpy array
+representing N vectors with start position and projection values in D dimensions,
+or it must be an N1xN2 ... xNDxD, array
+where each of the first D dimensions corresponds to the voxel of the location of the vector,
+and the last dimension contains the D values of the projection of that vector.
+The former representation is useful when you have vectors that can start in arbitrary positions in the canvas.
+The latter representation is useful when your vectors are defined on a grid,
+say corresponding to the voxels of an image,
+and you have one vector per grid.
 
 See here for the example from `examples/add_vectors_image.py` of a grid of vectors defined over a random image:
 
 ![image]({{ '/assets/tutorials/add_vectors_image.png' | relative_url }})
 
-Regardless of how the data is passed, we convert it to the Nx2xD representation internally. This representation is  accessible through the `layer.data` property.
+Regardless of how the data is passed, we convert it to the Nx2xD representation internally.
+This representation is  accessible through the `layer.data` property.
 
-Editing the start position of the vectors from the GUI is not possible. Nor is it possible to draw vectors from the GUI. If you want to draw lines from the GUI you should use the `Lines` shape inside a `Shapes` layer.
+Editing the start position of the vectors from the GUI is not possible.
+Nor is it possible to draw vectors from the GUI.
+If you want to draw lines from the GUI you should use the `Lines` shape inside a `Shapes` layer.
 
 ## 3D rendering of vectors
 
-All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer. See for example the `examples/nD_vectors.py` to see shapes in both 2D and 3D:
+All our layers can be rendered in both 2D and 3D mode,
+and one of our viewer buttons can toggle between each mode.
+The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+See for example the `examples/nD_vectors.py` to see shapes in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/nD_vectors.gif' | relative_url }})
 
@@ -99,40 +132,60 @@ You can also set the color of all the vectors in a layer using the `layer.edge_c
 
 ## layer visibility
 
-All our layers support a visibility toggle that allows you to set the `visible` property of each layer. This property is located inside the layer widget in the layers list and is represented by an eye icon.
+All our layers support a visibility toggle that allows you to set the `visible` property of each layer.
+This property is located inside the layer widget in the layers list and is represented by an eye icon.
 
 ## layer opacity
 
-All our layers support an opacity slider and `opacity` property that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible. The opacity value applies globally to all the vectors in the layer.
+All our layers support an opacity slider and `opacity` property
+that allow you to adjust the layer opacity between 0, fully invisible, and 1, fully visible.
+The opacity value applies globally to all the vectors in the layer.
 
 ## blending layers
 
-All our layers support three blending modes `translucent`, `additive`, and `opaque` that determine how the visuals for this layer get mixed with the visuals from the other layers.
+All our layers support three blending modes `translucent`, `additive`, and `opaque`
+that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile, and will fade to black as you decrease its opacity.
+An `opaque` layer renders all the other layers below it invisibile,
+and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity, but will fully block those layers if its opacity is 1. This is a reasonable default, useful for many applications.
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+but will fully block those layers if its opacity is 1.
+This is a reasonable default, useful for many applications.
 
-The final blending mode `additive` will cause the layer to blend with the layers below even when it has full opacity. This mode is very useful for visualizing multiple layers at the same time.
+The final blending mode `additive` will cause the layer to blend with the layers below
+even when it has full opacity.
+This mode is very useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
-All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list. The name of each layer is forced into being unique so that you can use the name to index into `viewer.layers` to retrieve the layer object.
+All our layers support a `name` property that can be set inside a text box inside the layer widget in the layers list.
+The name of each layer is forced into being unique
+so that you can use the name to index into `viewer.layers` to retrieve the layer object.
 
 ## scaling layers
 
-All our layers support a `scale` property and keyword argument that will rescale the layer multiplicatively according to the scale values (one for each dimension). This property can be particularly useful for viewing anisotropic data where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
+All our layers support a `scale` property and keyword argument
+that will rescale the layer multiplicatively according to the scale values (one for each dimension).
+This property can be particularly useful for viewing anisotropic data
+where the size of the voxel in the z dimension might be different then the size in the x and y dimensions.
 
 ## translating layers
 
-All our layers support a `translate` property and keyword argument that you can use to offset a layer relative to the other layers, which could be useful if you are trying to overlay two layers for image registration purposes.
+All our layers support a `translate` property and keyword argument
+that you can use to offset a layer relative to the other layers,
+which could be useful if you are trying to overlay two layers for image registration purposes.
 
 ## layer metadata
 
-All our layers also support a `metadata` property and keyword argument that you can use to store an arbitrary metadata dictionary on the layer.
+All our layers also support a `metadata` property and keyword argument
+that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer, including how to create one and control its properties. If you've explored all the other layer types that **napari** supports maybe checkout our [gallery]({{ '/gallery' | relative_url }}) for some cool examples of using napari with scientific data.
+Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer,
+including how to create one and control its properties.
+If you've explored all the other layer types that **napari** supports
+maybe checkout our [gallery]({{ '/gallery' | relative_url }}) for some cool examples of using napari with scientific data.
 
 {% include footer.md %}

--- a/fundamentals/vectors.md
+++ b/fundamentals/vectors.md
@@ -45,7 +45,8 @@ with napari.gui_qt():
 
 Both `view_vectors` and `add_vectors` have the following doc strings:
 
-```
+```python
+"""
 Parameters
 ----------
 vectors : (N, 2, D) or (N1, N2, ..., ND, D) array
@@ -67,6 +68,7 @@ Returns
 -------
 layer : napari.layers.Vectors
     The newly-created vectors layer.
+"""
 ```
 
 ## vectors data
@@ -77,7 +79,6 @@ See here for the example from `examples/add_vectors_image.py` of a grid of vecto
 
 ![image]({{ '/assets/tutorials/add_vectors_image.png' | relative_url }})
 
-
 Regardless of how the data is passed, we convert it to the Nx2xD representation internally. This representation is  accessible through the `layer.data` property.
 
 Editing the start position of the vectors from the GUI is not possible. Nor is it possible to draw vectors from the GUI. If you want to draw lines from the GUI you should use the `Lines` shape inside a `Shapes` layer.
@@ -87,7 +88,6 @@ Editing the start position of the vectors from the GUI is not possible. Nor is i
 All our layers can be rendered in both 2D and 3D mode, and one of our viewer buttons can toggle between each mode. The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer. See for example the `examples/nD_vectors.py` to see shapes in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/nD_vectors.gif' | relative_url }})
-
 
 ## changing vector length, width, and color
 

--- a/fundamentals/vectors.md
+++ b/fundamentals/vectors.md
@@ -19,7 +19,7 @@ including how to display many vectors simultaneously and adjust their properties
 At the end of the tutorial you should understand how to add a vectors layer
 and edit it from the GUI and from the console.
 
-The vectors layer allows you to display a many vectors with defined starting points and directions.
+The vectors layer allows you to display many vectors with defined starting points and directions.
 It is particularly useful for people who want to visualize large vector fields,
 for example if you are doing polarization microscopy.
 You can adjust the color, width, and length of all the vectors both programmatically and from the GUI.
@@ -117,7 +117,7 @@ If you want to draw lines from the GUI you should use the `Lines` shape inside a
 
 All our layers can be rendered in both 2D and 3D mode,
 and one of our viewer buttons can toggle between each mode.
-The number of dimensions sliders will be 2 or 3 less then the total number of dimensions of the layer.
+The number of dimensions sliders will be 2 or 3 less than the total number of dimensions of the layer.
 See for example the `examples/nD_vectors.py` to see shapes in both 2D and 3D:
 
 ![image]({{ '/assets/tutorials/nD_vectors.gif' | relative_url }})
@@ -146,16 +146,16 @@ The opacity value applies globally to all the vectors in the layer.
 All our layers support three blending modes `translucent`, `additive`, and `opaque`
 that determine how the visuals for this layer get mixed with the visuals from the other layers.
 
-An `opaque` layer renders all the other layers below it invisibile,
+An `opaque` layer renders all the other layers below it invisible
 and will fade to black as you decrease its opacity.
 
-The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity,
+The `translucent` setting will cause the layer to blend with the layers below it if you decrease its opacity
 but will fully block those layers if its opacity is 1.
 This is a reasonable default, useful for many applications.
 
 The final blending mode `additive` will cause the layer to blend with the layers below
 even when it has full opacity.
-This mode is very useful for visualizing multiple layers at the same time.
+This mode is especially useful for visualizing multiple layers at the same time.
 
 ## naming layers
 
@@ -183,7 +183,7 @@ that you can use to store an arbitrary metadata dictionary on the layer.
 
 ## next steps
 
-Hopefully this tutorial has given you a detailed understanding of the `Vectors` layer,
+Hopefully, this tutorial has given you a detailed understanding of the `Vectors` layer,
 including how to create one and control its properties.
 If you've explored all the other layer types that **napari** supports
 maybe checkout our [gallery]({{ '/gallery' | relative_url }}) for some cool examples of using napari with scientific data.

--- a/fundamentals/viewer.md
+++ b/fundamentals/viewer.md
@@ -18,7 +18,7 @@ the napari viewer can be launched from the command-line,
 a python script,
 an IPython console,
 or a jupyter notebook.
-All four methods launch the same viewer
+All four methods launch the same viewer,
 and anything related to the interacting with the viewer on the screen applies equally to all of them.
 We will use the syntax inside python scripts
 so you can copy and paste these examples into scripts and run them.
@@ -56,7 +56,7 @@ with napari.gui_qt():
 but doesn't create a `Viewer`, as you must already have one to use it.
 
 After running either of those two commands
-you should now be able to see the photograph of the astronaut in the a **napari** viewer as shown below
+you should now be able to see the photograph of the astronaut in the **napari** viewer as shown below
 
 ![image]({{ '/assets/tutorials/viewer_astronaut.png' | relative_url }})
 
@@ -83,7 +83,7 @@ We'll go through each of these in the next sections.
 
 ### main canvas
 
-The main canvas is located in the center of the viewer
+The main canvas is in the center of the viewer
 and contains the visual display of the data passed to **napari**,
 including images, point, shapes, and our other supported data types.
 Under the hood the canvas is a `vispy.scene.SceneCanvas` object
@@ -98,7 +98,7 @@ You can also return to the original zoom level by clicking the `home` button in 
 One of the basic **napari** objects are layers.
 There are different layer types for `Image`, `Points`, `Shapes`, and other basic data types.
 They can be added to the viewer either programmatically or through the GUI.
-Once added they start to populate the layer list is located on the bottom lefthand side of the main canvas.
+Once added they start to populate the layer list located on the bottom lefthand side of the main canvas.
 
 The layer list contains one widget for each of the layers that have been added to the viewer
 and includes a `thumbnail` which shows a miniaturized version of the currently viewed data,
@@ -106,7 +106,7 @@ a `name` that is an editable text box,
 `visibility` button that can be toggled on or off to show or hide the layer,
 and an `icon` for the layer type.
 
-Adding the following three image layers using the code below adds three layer widgets to the layer list as follows:
+Adding the following three image layers using the code below adds three-layer widgets to the layer list as follows:
 
 ```python
 from skimage import data
@@ -127,7 +127,7 @@ The layer name is coerced into being unique so that it can be used to index into
 
 You can select layers, causing them to become outlined, by clicking on their layer widget.
 Multiple layers can be simultaneously selected using either `shift` or `command` click
- to select either all the layers in between clicked on layers or just the clicked on layers respectively.
+ to select either all the layers in between clicked-on layers or just the clicked-on layers respectively.
 
 You can rearrange the order of the layers by dragging them,
 including dragging multiple layers at the same time.
@@ -138,7 +138,7 @@ The `Viewer` object also contains our `LayerList` object that allows you to acce
 viewer.layers
 ```
 
-This object can be indexed into like a normal list using an `int`
+This object can be indexed like a normal list using an `int`
 or using the `str` name of the layer as follows
 
 ```python
@@ -147,8 +147,8 @@ viewer.layers['astronaut']
 ```
 
 When you rearrange layers in the viewer you also rearrange them in the list.
-Similarly rearranging layers in the list rearranges them in the viewer.
-For example calling
+Similarly, rearranging layers in the list rearranges them in the viewer.
+For example, calling
 
 ```python
 viewer.layers['astronaut', 'moon'] = viewer.layers['moon', 'astronaut']
@@ -156,15 +156,15 @@ viewer.layers['astronaut', 'moon'] = viewer.layers['moon', 'astronaut']
 
 from the console will swap the positions of the `moon` and `astronaut` layers in the viewer.
 
-When you select a layer you will notice that layer controls box above the layers list
-becomes populate with options that depend on the layer type that you have selected.
+When you select a layer, you will notice that layer controls box above the layers list
+becomes populated with options that depend on the layer type that you have selected.
 
 ### layer controls
 
 Above the layers list in the top left corner of the viewer there is a box that contains the layer controls.
 The controls that you have available to you depend on the layer type that you have selected.
 
-For example if you add a `Points` layer after adding an `Image` layer you will now see different controls present.
+For example, if you add a `Points` layer after adding an `Image` layer you will now see different controls present.
 
 ```python
 from skimage import data
@@ -179,7 +179,7 @@ viewer.add_points(points, size=30)
 
 Adjusting these properties in the GUI will cause corresponding changes to properties on the individual layers that are accessible in the console through `viewer.layers`.
 
-For example the name and opacity of a layer can be changed within the console as follows:
+For example, the name and opacity of a layer can be changed within the console as follows:
 
 ```python
 viewer.layers[0].name = 'astronaut'
@@ -205,7 +205,7 @@ viewer.add_labels(data)
 but with empty data.
 Once added in the GUI these layers become accessible in the layers list and at `viewer.layers`.
 
-Layers can also be deleted by selecting them and the clicking on the trash icon,
+Layers can also be deleted by selecting them and then clicking on the trash icon,
 or by dragging the layers and dropping them into the trash.
 
 In the console a layer at index `i` can be removed by
@@ -221,21 +221,21 @@ While much consumer photography is 2D and `RGB`,
 scientific image data can often be volumetric (i.e. 3D),
 volumetric timeseries (i.e. 4D),
 or even higher dimensional.
-**napari** places no limits on the dimensionality of its input data for all of its layer types.
+**napari** places no limits on the dimensionality of its input data for all its layer types.
 
 Adding data with a dimensionality greater than 2D
 will cause dimension sliders to appear directly underneath the main canvas and above the status bar.
 As many sliders as needed will appear to ensure the data can be fully browsed.
-For example a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on.
-The widths of the scroll bars in the dimensions sliders
-is directly related to how many slices are in each dimension.
+For example, a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on.
+The widths of the scroll bars of the dimension sliders
+are directly related to how many slices are in each dimension.
 
 It is also possible to mix data of different shapes and dimensionality in different layers.
 If a 2D and 4D dataset are both added to the viewer
 then the sliders will only affect the 4D dataset and the 2D dataset will be remain the same.
 Effectively, the two datasets are broadcast together using [NumPy broadcasting rules](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
 
-For example the following commands from the console will add a both 2D and 3D datasets to the same viewer:
+For example, the following commands from the console will add a both 2D and 3D datasets to the same viewer:
 
 ```python
 import numpy as np
@@ -282,7 +282,7 @@ this will then show you the `ZY` slice.
 
 After that is a button that transposes the displayed dimensions.
 
-Finally there is the `home` button that will reset the camera state to its initial values.
+Finally, there is the `home` button that will reset the camera state to its initial values.
 
 ### status bar
 
@@ -315,16 +315,16 @@ and add one yourself!
 ## custom keybinding
 
 One of the promises of **napari** is to provide a beginner friendly environment for interactive analysis.
-For example we want to enable workflows where people can interact with the GUI,
+For example, we want to enable workflows where people can interact with the GUI,
 say click on the centers of some objects,
 or paint over some regions and then perform custom analysis.
 As a first step towards enabling custom interactivity
 we've provided support to add your own custom keybindings to the `Viewer` or individual `Layer` objects
 such that when the corresponding key gets clicked your custom function gets executed.
-Depending on which object you bind your key too
+Depending on which object you bind your key to,
 your function will either get access to the state of the entire `viewer` or `layer` object.
 
-For example to bind function that loops through all layers in the viewer
+For example, to bind function that loops through all layers in the viewer
 and prints their names to your console when you press the `p` key you can do the following:
 
 ```python
@@ -338,7 +338,7 @@ def print_names(viewer):
     print([layer.name for layer in viewer.layers])
 ```
 
-By default your key will bind to the key press event,
+By default, your key will bind to the key press event,
 but it is also possible to bind to the key release event by including a `yield` inside your function.
 All code before the `yield` will get executed on key press
 and all code after the `yield` will get executed on key release.
@@ -363,7 +363,7 @@ Keys can be bound both to the object class or a particular instance
 depending on if you want the keybinding to apply to all instances of the class
 or only one particular instance.
 
-Currently the keybindings only worked when the main canvas is in focus,
+Currently the keybindings only work when the main canvas is in focus,
 we are working to ensure they always work.
 
 The ability to add custom keybindings dramatically increases what is possible within **napari**
@@ -371,7 +371,7 @@ and we hope you take full advantage of them.
 
 ## next steps
 
-Hopefully this tutorial has given you an overview of the functionality available on the **napari** viewer,
+Hopefully, this tutorial has given you an overview of the functionality available on the **napari** viewer,
 including the `LayerList` and some of the different layer types.
 To learn more about the different layer types that **napari** supports
 checkout some more of our tutorials listed below.

--- a/fundamentals/viewer.md
+++ b/fundamentals/viewer.md
@@ -2,13 +2,27 @@
 
 Welcome to the tutorial on the **napari** viewer!
 
-This tutorial assumes you have already installed **napari** and know how to launch the viewer. For help with installation see our [installation](./installation) tutorial. For help getting started with the viewer see our [getting started](./getting_started) tutorial.
+This tutorial assumes you have already installed **napari** and know how to launch the viewer.
+For help with installation see our [installation](./installation) tutorial.
+For help getting started with the viewer see our [getting started](./getting_started) tutorial.
 
-This tutorial will teach you about the **napari** viewer, including how to use its graphical user interface (GUI) and how the data within it is organized. At the end of the tutorial you should understand the both the layout of the viewer on the screen and the data inside of it.
+This tutorial will teach you about the **napari** viewer,
+including how to use its graphical user interface (GUI)
+and how the data within it is organized.
+At the end of the tutorial you should understand the both the layout of the viewer on the screen and the data inside of it.
 
 ## launching the viewer
 
-As discussed in [getting started](./getting_started) tutorial the napari viewer can be launched from the command-line, a python script, an IPython console, or a jupyter notebook. All four methods launch the same viewer and anything related to the interacting with the viewer on the screen applies equally to all of them. We will use the syntax inside python scripts so you can copy and paste these examples into scripts and run them. If you are using as IPython console (launched with `IPython --gui=qt`) then you won't need to use the `napari.gui_qt` context.
+As discussed in [getting started](./getting_started) tutorial
+the napari viewer can be launched from the command-line,
+a python script,
+an IPython console,
+or a jupyter notebook.
+All four methods launch the same viewer
+and anything related to the interacting with the viewer on the screen applies equally to all of them.
+We will use the syntax inside python scripts
+so you can copy and paste these examples into scripts and run them.
+If you are using as IPython console (launched with `IPython --gui=qt`) then you won't need to use the `napari.gui_qt` context.
 
 Let's get stated by launching a viewer with a simple 2D image.
 
@@ -22,9 +36,12 @@ with napari.gui_qt():
     viewer = napari.view_image(data.astronaut(), rgb=True)
 ```
 
-Calling `napari.view_image` will return a `Viewer` object that is the main object inside **napari**. All the data you add to **napari** will be stored inside the `Viewer` object and will be accessible from it. This command will also open the viewer to create a GUI that you can interact with.
+Calling `napari.view_image` will return a `Viewer` object that is the main object inside **napari**.
+All the data you add to **napari** will be stored inside the `Viewer` object and will be accessible from it.
+This command will also open the viewer to create a GUI that you can interact with.
 
-You can also create an empty `Viewer` directly and then start adding images to it. For example:
+You can also create an empty `Viewer` directly and then start adding images to it.
+For example:
 
 ```python
 from skimage import data
@@ -35,13 +52,19 @@ with napari.gui_qt():
     viewer.add_image(data.astronaut(), rgb=True)
 ```
 
-`add_image` accepts the same arguments as `view_image` but doesn't create a `Viewer`, as you must already have one to use it.
+`add_image` accepts the same arguments as `view_image`
+but doesn't create a `Viewer`, as you must already have one to use it.
 
-After running either of those two commands you should now be able to see the photograph of the astronaut in the a **napari** viewer as shown below
+After running either of those two commands
+you should now be able to see the photograph of the astronaut in the a **napari** viewer as shown below
 
 ![image]({{ '/assets/tutorials/viewer_astronaut.png' | relative_url }})
 
-Both the `view_image` and the `add_image` methods accept any numpy-array like object as an input, including n-dimensional arrays. For more information on adding images to the viewer see the [image layer](./image) tutorial. Now we will continue exploring the rest of the viewer.
+Both the `view_image` and the `add_image` methods accept any numpy-array like object as an input,
+including n-dimensional arrays.
+For more information on adding images to the viewer
+see the [image layer](./image) tutorial.
+Now we will continue exploring the rest of the viewer.
 
 ## layout of the viewer
 
@@ -60,15 +83,28 @@ We'll go through each of these in the next sections.
 
 ### main canvas
 
-The main canvas is located in the center of the viewer and contains the visual display of the data passed to **napari**, including images, point, shapes, and our other supported data types. Under the hood the canvas is a `vispy.scene.SceneCanvas` object which has built-in support for features such as zooming and panning. As `vispy` uses `OpenGL` and your graphics card, panning and zooming are highly performant. You can also return to the original zoom level by clicking the `home` button in the viewer buttons panel.
+The main canvas is located in the center of the viewer
+and contains the visual display of the data passed to **napari**,
+including images, point, shapes, and our other supported data types.
+Under the hood the canvas is a `vispy.scene.SceneCanvas` object
+which has built-in support for features such as zooming and panning.
+As `vispy` uses `OpenGL` and your graphics card, panning and zooming are highly performant.
+You can also return to the original zoom level by clicking the `home` button in the viewer buttons panel.
 
 ![image]({{ '/assets/tutorials/viewer_pan_zoom.gif' | relative_url }})
 
 ### layer list
 
-One of the basic **napari** objects are layers. There are different layer types for `Image`, `Points`, `Shapes`, and other basic data types. They can be added to the viewer either programmatically or through the GUI. Once added they start to populate the layer list is located on the bottom lefthand side of the main canvas.
+One of the basic **napari** objects are layers.
+There are different layer types for `Image`, `Points`, `Shapes`, and other basic data types.
+They can be added to the viewer either programmatically or through the GUI.
+Once added they start to populate the layer list is located on the bottom lefthand side of the main canvas.
 
-The layer list contains one widget for each of the layers that have been added to the viewer and includes a `thumbnail` which shows a miniaturized version of the currently viewed data, a `name` that is an editable text box, `visibility` button that can be toggled on or off to show or hide the layer, and an `icon` for the layer type.
+The layer list contains one widget for each of the layers that have been added to the viewer
+and includes a `thumbnail` which shows a miniaturized version of the currently viewed data,
+a `name` that is an editable text box,
+`visibility` button that can be toggled on or off to show or hide the layer,
+and an `icon` for the layer type.
 
 Adding the following three image layers using the code below adds three layer widgets to the layer list as follows:
 
@@ -85,11 +121,16 @@ with napari.gui_qt():
 
 ![image]({{ '/assets/tutorials/layerlist.png' | relative_url }})
 
-Note that we've also also named each of the layers using the `name` keyword argument in `add_image`, and that name has appeared as a string in the layer widget. The layer name is coerced into being unique so that it can be used to index into the `LayerList`.
+Note that we've also also named each of the layers using the `name` keyword argument in `add_image`,
+and that name has appeared as a string in the layer widget.
+The layer name is coerced into being unique so that it can be used to index into the `LayerList`.
 
-You can select layers, causing them to become outlined, by clicking on their layer widget. Multiple layers can be simultaneously selected using either `shift` or `command` click to select either all the layers in between clicked on layers or just the clicked on layers respectively.
+You can select layers, causing them to become outlined, by clicking on their layer widget.
+Multiple layers can be simultaneously selected using either `shift` or `command` click
+ to select either all the layers in between clicked on layers or just the clicked on layers respectively.
 
-You can rearrange the order of the layers by dragging them, including dragging multiple layers at the same time.
+You can rearrange the order of the layers by dragging them,
+including dragging multiple layers at the same time.
 
 The `Viewer` object also contains our `LayerList` object that allows you to access the data of all the layers by
 
@@ -97,14 +138,17 @@ The `Viewer` object also contains our `LayerList` object that allows you to acce
 viewer.layers
 ```
 
-This object can be indexed into like a normal list using an `int` or using the `str` name of the layer as follows
+This object can be indexed into like a normal list using an `int`
+or using the `str` name of the layer as follows
 
 ```python
 viewer.layers[0]
 viewer.layers['astronaut']
 ```
 
-When you rearrange layers in the viewer you also rearrange them in the list. Similarly rearranging layers in the list rearranges them in the viewer. For example calling
+When you rearrange layers in the viewer you also rearrange them in the list.
+Similarly rearranging layers in the list rearranges them in the viewer.
+For example calling
 
 ```python
 viewer.layers['astronaut', 'moon'] = viewer.layers['moon', 'astronaut']
@@ -112,11 +156,13 @@ viewer.layers['astronaut', 'moon'] = viewer.layers['moon', 'astronaut']
 
 from the console will swap the positions of the `moon` and `astronaut` layers in the viewer.
 
-When you select a layer you will notice that layer controls box above the layers list becomes populate with options that depend on the layer type that you have selected.
+When you select a layer you will notice that layer controls box above the layers list
+becomes populate with options that depend on the layer type that you have selected.
 
 ### layer controls
 
-Above the layers list in the top left corner of the viewer there is a box that contains the layer controls. The controls that you have available to you depend on the layer type that you have selected.
+Above the layers list in the top left corner of the viewer there is a box that contains the layer controls.
+The controls that you have available to you depend on the layer type that you have selected.
 
 For example if you add a `Points` layer after adding an `Image` layer you will now see different controls present.
 
@@ -140,11 +186,15 @@ viewer.layers[0].name = 'astronaut'
 viewer.layers[0].opacity = 0.7
 ```
 
-and these changes will instantly propagate to the GUI. For more information about the different properties for different layer types please see our layer specific tutorials listed at the bottom of this tutorial.
+and these changes will instantly propagate to the GUI.
+For more information about the different properties for different layer types
+please see our layer specific tutorials listed at the bottom of this tutorial.
 
 ### new layer buttons
 
-New `Points`, `Shapes`, and `Labels` layers can be added to the viewer using the new layer buttons in the bottom righthand corner of the GUI. These correspond to the calls such as:
+New `Points`, `Shapes`, and `Labels` layers can be added to the viewer
+using the new layer buttons in the bottom righthand corner of the GUI.
+These correspond to the calls such as:
 
 ```python
 viewer.add_points(data)
@@ -152,9 +202,11 @@ viewer.add_shapes(data)
 viewer.add_labels(data)
 ```
 
-but with empty data. Once added in the GUI these layers become accessible in the layers list and at `viewer.layers`.
+but with empty data.
+Once added in the GUI these layers become accessible in the layers list and at `viewer.layers`.
 
-Layers can also be deleted by selecting them and the clicking on the trash icon, or by dragging the layers and dropping them into the trash.
+Layers can also be deleted by selecting them and the clicking on the trash icon,
+or by dragging the layers and dropping them into the trash.
 
 In the console a layer at index `i` can be removed by
 
@@ -164,11 +216,24 @@ viewer.layers.pop(i)
 
 ## dimension sliders
 
-One of the main strengths of **napari** is that it has been designed from the beginning to handle n-dimensional data. While much consumer photography is 2D and `RGB`, scientific image data can often be volumetric (i.e. 3D), volumetric timeseries (i.e. 4D), or even higher dimensional. **napari** places no limits on the dimensionality of its input data for all of its layer types.
+One of the main strengths of **napari** is that it has been designed from the beginning to handle n-dimensional data.
+While much consumer photography is 2D and `RGB`,
+scientific image data can often be volumetric (i.e. 3D),
+volumetric timeseries (i.e. 4D),
+or even higher dimensional.
+**napari** places no limits on the dimensionality of its input data for all of its layer types.
 
-Adding data with a dimensionality greater than 2D will cause dimension sliders to appear directly underneath the main canvas and above the status bar. As many sliders as needed will appear to ensure the data can be fully browsed. For example a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on. The widths of the scroll bars in the dimensions sliders is directly related to how many slices are in each dimension.
+Adding data with a dimensionality greater than 2D
+will cause dimension sliders to appear directly underneath the main canvas and above the status bar.
+As many sliders as needed will appear to ensure the data can be fully browsed.
+For example a 3D dataset needs one slider, a 4D dataset needs two sliders, and so on.
+The widths of the scroll bars in the dimensions sliders
+is directly related to how many slices are in each dimension.
 
-It is also possible to mix data of different shapes and dimensionality in different layers. If a 2D and 4D dataset are both added to the viewer then the sliders will only affect the 4D dataset and the 2D dataset will be remain the same. Effectively, the two datasets are broadcast together using [NumPy broadcasting rules](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
+It is also possible to mix data of different shapes and dimensionality in different layers.
+If a 2D and 4D dataset are both added to the viewer
+then the sliders will only affect the 4D dataset and the 2D dataset will be remain the same.
+Effectively, the two datasets are broadcast together using [NumPy broadcasting rules](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html).
 
 For example the following commands from the console will add a both 2D and 3D datasets to the same viewer:
 
@@ -195,17 +260,25 @@ viewer.add_image(blobs, name='blobs', opacity=0.5, colormap='red')
 
 ### viewer buttons
 
-Underneath the layers list there is a row of buttons that includes the `Console` button that will show or hide our console that allows you to interact with a python kernel. Inside the console you can access the viewer using the `viewer` argument.
+Underneath the layers list there is a row of buttons that includes the `Console` button
+that will show or hide our console that allows you to interact with a python kernel.
+Inside the console you can access the viewer using the `viewer` argument.
 
-When the console button is clicked, the console will appear at the bottom of the viewer as follows:
+When the console button is clicked,
+the console will appear at the bottom of the viewer as follows:
 
 ![image]({{ '/assets/tutorials/console.png' | relative_url }})
 
-We then have a button that switches between `2D` and `3D` rendering. Running the `examples/nD_labels.py` and clicking on the 3D button gives the following view:
+We then have a button that switches between `2D` and `3D` rendering.
+Running the `examples/nD_labels.py`
+and clicking on the 3D button gives the following view:
 
 ![image]({{ '/assets/tutorials/nD_labels.png' | relative_url }})
 
-Next to the 2D / 3D button is a button to roll the dimensions that are currently being displayed in the viewer - for example if you have a `ZYX` volume and are looking at the `YX` slice this will then show you the `ZY` slice.
+Next to the 2D / 3D button is a button to roll the dimensions that are currently being displayed in the viewer -
+for example if you have a `ZYX` volume
+and are looking at the `YX` slice
+this will then show you the `ZY` slice.
 
 After that is a button that transposes the displayed dimensions.
 
@@ -215,9 +288,12 @@ Finally there is the `home` button that will reset the camera state to its initi
 
 At the very bottom of the GUI there is a status bar that contains useful updates and tips.
 
-On the lefthand side of the status bar there is a message that contains information about the position of the mouse and the values of any images or the indices of any points that are currently hovered over, depending on which layer is selected. The status bar will also display information about what button you are clicking in the layer control panel too.
+On the lefthand side of the status bar there is a message that contains information about the position of the mouse
+and the values of any images or the indices of any points that are currently hovered over, depending on which layer is selected.
+The status bar will also display information about what button you are clicking in the layer control panel too.
 
-The righthand side of the status bar contains some helpful tips depending on which layer and tools are currently selected.
+The righthand side of the status bar contains some helpful tips
+depending on which layer and tools are currently selected.
 
 ## changing viewer theme
 
@@ -230,23 +306,26 @@ viewer.theme = 'light'
 
 ![image]({{ '/assets/tutorials/viewer_theme_light.png' | relative_url }})
 
-Adding your own custom theme isn't too hard either but does require creating your own color `palette`
-and rebuilding the icons. If people want more themes, we're happy to add them or if you look at
-our [contributing guidelines](https://github.com/napari/napari/tree/master/docs/CONTRIBUTING) for more information about building the icons and
-add one yourself!
+Adding your own custom theme isn't too hard either
+but does require creating your own color `palette` and rebuilding the icons.
+If people want more themes, we're happy to add them
+or if you look at our [contributing guidelines](https://github.com/napari/napari/tree/master/docs/CONTRIBUTING) for more information about building the icons
+and add one yourself!
 
 ## custom keybinding
 
-One of the promises of **napari** is to provide a beginner friendly environment for interactive
-analysis. For example we want to enable workflows where people can interact with the GUI, say
-click on the centers of some objects, or paint over some regions and then perform custom analysis.
-As a first step towards enabling custom interactivity we've provided support to add your own custom
-keybindings to the `Viewer` or individual `Layer` objects such that when the corresponding key gets
-clicked your custom function gets executed. Depending on which object you bind your key too your function
-will either get access to the state of the entire `viewer` or `layer` object.
+One of the promises of **napari** is to provide a beginner friendly environment for interactive analysis.
+For example we want to enable workflows where people can interact with the GUI,
+say click on the centers of some objects,
+or paint over some regions and then perform custom analysis.
+As a first step towards enabling custom interactivity
+we've provided support to add your own custom keybindings to the `Viewer` or individual `Layer` objects
+such that when the corresponding key gets clicked your custom function gets executed.
+Depending on which object you bind your key too
+your function will either get access to the state of the entire `viewer` or `layer` object.
 
-For example to bind function that loops through all layers in the viewer and prints their names to your console when you
-press the `p` key you can do the following:
+For example to bind function that loops through all layers in the viewer
+and prints their names to your console when you press the `p` key you can do the following:
 
 ```python
 import napari
@@ -259,10 +338,12 @@ def print_names(viewer):
     print([layer.name for layer in viewer.layers])
 ```
 
-By default your key will bind to the key press event, but it is also possible to bind to the key release
-event by including a `yield` inside your function. All code before the `yield` will get executed on key
-press and all code after the `yield` will get executed on key release. The following example will print `hello`
-when you start to press the `m` key and print `goodbye` when you release it.
+By default your key will bind to the key press event,
+but it is also possible to bind to the key release event by including a `yield` inside your function.
+All code before the `yield` will get executed on key press
+and all code after the `yield` will get executed on key release.
+The following example will print `hello` when you start to press the `m` key
+and print `goodbye` when you release it.
 
 ```python
 import napari
@@ -278,17 +359,23 @@ def print_message(viewer):
     print('goodbye')
 ```
 
-Keys can be bound both to the object class or a particular instance depending on if you want the keybinding
-to apply to all instances of the class or only one particular instance.
+Keys can be bound both to the object class or a particular instance
+depending on if you want the keybinding to apply to all instances of the class
+or only one particular instance.
 
-Currently the keybindings only worked when the main canvas is in focus, we are working to ensure they always work.
+Currently the keybindings only worked when the main canvas is in focus,
+we are working to ensure they always work.
 
-The ability to add custom keybindings dramatically increases what is possible within **napari** and we hope
-you take full advantage of them.
+The ability to add custom keybindings dramatically increases what is possible within **napari**
+and we hope you take full advantage of them.
 
 ## next steps
 
-Hopefully this tutorial has given you an overview of the functionality available on the **napari** viewer, including
-the `LayerList` and some of the different layer types. To learn more about the different layer types that **napari** supports checkout some more of our tutorials listed below. The [image layer](./image) tutorial is a great one to try next as viewing images is a fundamental part of what **napari** is about.
+Hopefully this tutorial has given you an overview of the functionality available on the **napari** viewer,
+including the `LayerList` and some of the different layer types.
+To learn more about the different layer types that **napari** supports
+checkout some more of our tutorials listed below.
+The [image layer](./image) tutorial is a great one to try next
+as viewing images is a fundamental part of what **napari** is about.
 
 {% include footer.md %}

--- a/fundamentals/viewer.md
+++ b/fundamentals/viewer.md
@@ -6,8 +6,8 @@ This tutorial assumes you have already installed **napari** and know how to laun
 
 This tutorial will teach you about the **napari** viewer, including how to use its graphical user interface (GUI) and how the data within it is organized. At the end of the tutorial you should understand the both the layout of the viewer on the screen and the data inside of it.
 
-
 ## launching the viewer
+
 As discussed in [getting started](./getting_started) tutorial the napari viewer can be launched from the command-line, a python script, an IPython console, or a jupyter notebook. All four methods launch the same viewer and anything related to the interacting with the viewer on the screen applies equally to all of them. We will use the syntax inside python scripts so you can copy and paste these examples into scripts and run them. If you are using as IPython console (launched with `IPython --gui=qt`) then you won't need to use the `napari.gui_qt` context.
 
 Let's get stated by launching a viewer with a simple 2D image.
@@ -21,6 +21,7 @@ import napari
 with napari.gui_qt():
     viewer = napari.view_image(data.astronaut(), rgb=True)
 ```
+
 Calling `napari.view_image` will return a `Viewer` object that is the main object inside **napari**. All the data you add to **napari** will be stored inside the `Viewer` object and will be accessible from it. This command will also open the viewer to create a GUI that you can interact with.
 
 You can also create an empty `Viewer` directly and then start adding images to it. For example:
@@ -64,6 +65,7 @@ The main canvas is located in the center of the viewer and contains the visual d
 ![image]({{ '/assets/tutorials/viewer_pan_zoom.gif' | relative_url }})
 
 ### layer list
+
 One of the basic **napari** objects are layers. There are different layer types for `Image`, `Points`, `Shapes`, and other basic data types. They can be added to the viewer either programmatically or through the GUI. Once added they start to populate the layer list is located on the bottom lefthand side of the main canvas.
 
 The layer list contains one widget for each of the layers that have been added to the viewer and includes a `thumbnail` which shows a miniaturized version of the currently viewed data, a `name` that is an editable text box, `visibility` button that can be toggled on or off to show or hide the layer, and an `icon` for the layer type.
@@ -94,17 +96,20 @@ The `Viewer` object also contains our `LayerList` object that allows you to acce
 ```python
 viewer.layers
 ```
+
 This object can be indexed into like a normal list using an `int` or using the `str` name of the layer as follows
 
 ```python
 viewer.layers[0]
 viewer.layers['astronaut']
 ```
+
 When you rearrange layers in the viewer you also rearrange them in the list. Similarly rearranging layers in the list rearranges them in the viewer. For example calling
 
 ```python
 viewer.layers['astronaut', 'moon'] = viewer.layers['moon', 'astronaut']
 ```
+
 from the console will swap the positions of the `moon` and `astronaut` layers in the viewer.
 
 When you select a layer you will notice that layer controls box above the layers list becomes populate with options that depend on the layer type that you have selected.
@@ -114,6 +119,7 @@ When you select a layer you will notice that layer controls box above the layers
 Above the layers list in the top left corner of the viewer there is a box that contains the layer controls. The controls that you have available to you depend on the layer type that you have selected.
 
 For example if you add a `Points` layer after adding an `Image` layer you will now see different controls present.
+
 ```python
 from skimage import data
 import napari
@@ -136,7 +142,6 @@ viewer.layers[0].opacity = 0.7
 
 and these changes will instantly propagate to the GUI. For more information about the different properties for different layer types please see our layer specific tutorials listed at the bottom of this tutorial.
 
-
 ### new layer buttons
 
 New `Points`, `Shapes`, and `Labels` layers can be added to the viewer using the new layer buttons in the bottom righthand corner of the GUI. These correspond to the calls such as:
@@ -146,11 +151,13 @@ viewer.add_points(data)
 viewer.add_shapes(data)
 viewer.add_labels(data)
 ```
+
 but with empty data. Once added in the GUI these layers become accessible in the layers list and at `viewer.layers`.
 
 Layers can also be deleted by selecting them and the clicking on the trash icon, or by dragging the layers and dropping them into the trash.
 
 In the console a layer at index `i` can be removed by
+
 ```python
 viewer.layers.pop(i)
 ```
@@ -204,7 +211,6 @@ After that is a button that transposes the displayed dimensions.
 
 Finally there is the `home` button that will reset the camera state to its initial values.
 
-
 ### status bar
 
 At the very bottom of the GUI there is a status bar that contains useful updates and tips.
@@ -213,11 +219,11 @@ On the lefthand side of the status bar there is a message that contains informat
 
 The righthand side of the status bar contains some helpful tips depending on which layer and tools are currently selected.
 
-
 ## changing viewer theme
 
 Currently, **napari** comes with two different themes `light` and `dark`, which is the default.
 To change the theme just update `theme` property of the viewer, for example
+
 ```python
 viewer.theme = 'light'
 ```

--- a/gallery.md
+++ b/gallery.md
@@ -36,6 +36,7 @@ Or rendered in 3D as a volumetric timeseries.
 Note that the volume has been downsampled in each spatial axis by a factor of four before displaying it.
 
 ### neural calcium imaging data
+
 ![image](./assets/gallery/calcium_imaging.gif)
 
 This example shows calcium imaging of neurons to record neural activity, and is one of the example datasets in the [neurofinder](http://neurofinder.codeneuro.org/) image segmentation challenge. The bottom `Image` layer contains timeseries of the neural activity. The top `Labels` layer contains the segmented neuron regions. The middle two `Image` layers contain helpful processed maps, the mean and the local correlation of the timeseries.
@@ -87,6 +88,7 @@ We can also visualize the flourescent data as `Volume` layers too.
 Data from Allen Cell.
 
 ### more cell biology data
+
 ![image](./assets/gallery/cells.gif)
 
 This example shows 3 color channels of data of cell nuclei, membranes, and cytoplasm represented using three different `Image` layers with different colormaps, blended together. The top `Points` layer contains markers over the centers of the cell nuclei. The second from the top `Shapes` layer, contains polygon representations of the boundaries of the cells. Data from ImageJ examples.
@@ -94,16 +96,19 @@ This example shows 3 color channels of data of cell nuclei, membranes, and cytop
 During the example we edit the position of some of the points, and shapes, including deleting existing ones and adding new ones.
 
 ### volumetric rendering data
+
 ![image](./assets/gallery/stent.gif)
 
 This example shows 3D rendering of a stent, and includes the changing of colormaps and color limits. Data from vispy examples.
 
 ### geospatial data
+
 ![image](./assets/gallery/geospatial.gif)
 
 This example shows data from the [landsat-8](https://landsat.gsfc.nasa.gov/landsat-8/mission-details/) survey.
 
 ### kaggle nuclei segmentation data
+
 ![image](./assets/gallery/DSB2018_browse.gif)
 
 This example browses data from the [2018 kaggle data science bowl](https://www.kaggle.com/c/data-science-bowl-2018) on nuclei segmentation. The raw images are visualized using an `Image` layer and the segmentations are visualized using a `Labels` layer.
@@ -115,6 +120,7 @@ We can also edit or create our own segmentations using the paintbrush and fill b
 ![image](./assets/gallery/DSB2018_edit.gif)
 
 ### machine learning data
+
 ![image](./assets/gallery/ants_bees.gif)
 
 This example shows data from a [hymenoptera classification task](https://pytorch.org/tutorials/beginner/transfer_learning_tutorial.html) where the goal is to separate the images of the ants and bees. Here we are using [dask-image](https://dask-image.readthedocs.io) to look at two directories of images and lazily load each image when requested by the slider. This method can support easy browsing of training datasets with many many images as we never need to load all the images into memory. Note that not all images need to be the same size either.

--- a/gallery.md
+++ b/gallery.md
@@ -38,7 +38,7 @@ During the gif you can see us add a new `Shapes` layer and start drawing shapes 
 ![image](./assets/gallery/LLSM.gif)
 
 This example browses over 100GB of [lattice lightsheet](https://science.sciencemag.org/content/360/6386/eaaq1392) data, representing a volumetric timeseries.
-Using the sliders we can move through both the `z` dimension and the `time` dimension.
+Using the sliders, we can move through both the `z` dimension and the `time` dimension.
 The data is stored on disk as a [zarr](https://zarr.readthedocs.io) file,
 which are lazily reading using [dask](https://dask.readthedocs.io/en/latest/).
 
@@ -52,14 +52,14 @@ Note that the volume has been downsampled in each spatial axis by a factor of fo
 
 ![image](./assets/gallery/calcium_imaging.gif)
 
-This example shows calcium imaging of neurons to record neural activity,
+This example shows calcium imaging of neurons to record neural activity
 and is one of the example datasets in the [neurofinder](http://neurofinder.codeneuro.org/) image segmentation challenge.
 The bottom `Image` layer contains timeseries of the neural activity.
 The top `Labels` layer contains the segmented neuron regions.
 The middle two `Image` layers contain helpful processed maps,
 the mean and the local correlation of the timeseries.
 
-In this example we use the paintbrush and fill bucket tools in the `Labels`
+In this example we use the paintbrush and fill bucket tools in the `Labels` layer
 to separate two regions that were incorrectly merged and two add two regions that were missed.
 
 ### mesoscope neural imaging data
@@ -95,7 +95,7 @@ where each colored region corresponds to a different part of the brain.
 
 ![image](./assets/gallery/smFISH.gif)
 
-This examples shows some image-based transcriptomics data analyzed with the [starfish tool](https://spacetx-starfish.readthedocs.io/en/latest/).
+This example shows some image-based transcriptomics data analyzed with the [starfish tool](https://spacetx-starfish.readthedocs.io/en/latest/).
 Each spot in the image corresponds to an mRNA molecule.
 The bottom `Image` layer is the raw image data.
 The middle `Image` layer is the raw data after a learnt deconvolution,
@@ -114,11 +114,11 @@ Data courtesy of Tim Wang, Svoboda Lab.
 
 ![image](./assets/gallery/allen_cell.gif)
 
-This examples shows images of cells under brightfield and fluorescent imaging.
+This example shows images of cells under brightfield and fluorescent imaging.
 There are four color channels of flourescently label data all blended together,
 showing the cell nuclei and the distribution of targets of interest.
 The top `Labels` layer shows some hand drawn regions around the nuclei,
-which can been seen in blue.
+which can be seen in blue.
 
 We can also visualize the flourescent data as `Volume` layers too.
 
@@ -144,7 +144,7 @@ including deleting existing ones and adding new ones.
 
 ![image](./assets/gallery/stent.gif)
 
-This example shows 3D rendering of a stent,
+This example shows 3D rendering of a stent
 and includes the changing of colormaps and color limits.
 Data from vispy examples.
 
@@ -164,7 +164,7 @@ and the segmentations are visualized using a `Labels` layer.
 
 We are using [dask-image](https://dask-image.readthedocs.io) to look at directories of the images
 and labels and lazily them when requested by the slider.
-This method can support easy browsing of training datasets with many many examples
+This method can support easy browsing of training datasets with many examples
 as we never need to load all the images into memory.
 Note that not all images need to be the same size either.
 
@@ -180,7 +180,7 @@ This example shows data from a [hymenoptera classification task](https://pytorch
 where the goal is to separate the images of the ants and bees.
 Here we are using [dask-image](https://dask-image.readthedocs.io) to look at two directories of images
 and lazily load each image when requested by the slider.
-This method can support easy browsing of training datasets with many many images
+This method can support easy browsing of training datasets with many images
 as we never need to load all the images into memory.
 Note that not all images need to be the same size either.
 

--- a/gallery.md
+++ b/gallery.md
@@ -2,7 +2,11 @@
 
 Welcome to the **napari** gallery!
 
-This gallery contains examples showing real scientific data visualized and annotated with **napari**. Note that some of these examples were made with napari 0.1, before the UI upgraded in the 0.2 release, so they layout might look a little different in your version of napari, but all these functionalities and more are still supported.
+This gallery contains examples showing real scientific data visualized and annotated with **napari**.
+Note that some of these examples were made with napari 0.1,
+before the UI upgraded in the 0.2 release,
+so they layout might look a little different in your version of napari,
+but all these functionalities and more are still supported.
 
 | | | | |
 |---|---|---|---|
@@ -17,17 +21,26 @@ This gallery contains examples showing real scientific data visualized and annot
 
 ![image](./assets/gallery/pathology.gif)
 
-This example shows an ~100k x 200k pixel pathology slide from the [camelyon 16 challenge](https://camelyon17.grand-challenge.org/Data/) for cancer detection in pathology images. We converted the multiresolution image pyramid data into a [zarr](https://zarr.readthedocs.io) file, which we could lazily read using [dask](https://dask.readthedocs.io/en/latest/), a python library for flexible parallel computation.
+This example shows an ~100k x 200k pixel pathology slide from the [camelyon 16 challenge](https://camelyon17.grand-challenge.org/Data/) for cancer detection in pathology images.
+We converted the multiresolution image pyramid data into a [zarr](https://zarr.readthedocs.io) file, 
+which we could lazily read using [dask](https://dask.readthedocs.io/en/latest/),
+a python library for flexible parallel computation.
 
-We visualized the slide using a `Pyramid` layer. This layer allows us to dynamically swap in different resolution levels and image tiles depending on the zoom level so we can easily browse this large dataset without having to load it all into memory.
+We visualized the slide using a `Pyramid` layer.
+This layer allows us to dynamically swap in different resolution levels and image tiles depending on the zoom level
+so we can easily browse this large dataset without having to load it all into memory.
 
-We also extracted the coordinates of two tumors on this slide and visualized them us a `Shapes` layer. During the gif you can see us add a new `Shapes` layer and start drawing shapes over both whole areas of tissue and individual cells.
+We also extracted the coordinates of two tumors on this slide and visualized them us a `Shapes` layer.
+During the gif you can see us add a new `Shapes` layer and start drawing shapes over both whole areas of tissue and individual cells.
 
 ### lattice light-sheet data
 
 ![image](./assets/gallery/LLSM.gif)
 
-This example browses over 100GB of [lattice lightsheet](https://science.sciencemag.org/content/360/6386/eaaq1392) data, representing a volumetric timeseries. Using the sliders we can move through both the `z` dimension and the `time` dimension. The data is stored on disk as a [zarr](https://zarr.readthedocs.io) file, which are lazily reading using [dask](https://dask.readthedocs.io/en/latest/).
+This example browses over 100GB of [lattice lightsheet](https://science.sciencemag.org/content/360/6386/eaaq1392) data, representing a volumetric timeseries.
+Using the sliders we can move through both the `z` dimension and the `time` dimension.
+The data is stored on disk as a [zarr](https://zarr.readthedocs.io) file,
+which are lazily reading using [dask](https://dask.readthedocs.io/en/latest/).
 
 Or rendered in 3D as a volumetric timeseries.
 
@@ -39,39 +52,61 @@ Note that the volume has been downsampled in each spatial axis by a factor of fo
 
 ![image](./assets/gallery/calcium_imaging.gif)
 
-This example shows calcium imaging of neurons to record neural activity, and is one of the example datasets in the [neurofinder](http://neurofinder.codeneuro.org/) image segmentation challenge. The bottom `Image` layer contains timeseries of the neural activity. The top `Labels` layer contains the segmented neuron regions. The middle two `Image` layers contain helpful processed maps, the mean and the local correlation of the timeseries.
+This example shows calcium imaging of neurons to record neural activity,
+and is one of the example datasets in the [neurofinder](http://neurofinder.codeneuro.org/) image segmentation challenge.
+The bottom `Image` layer contains timeseries of the neural activity.
+The top `Labels` layer contains the segmented neuron regions.
+The middle two `Image` layers contain helpful processed maps,
+the mean and the local correlation of the timeseries.
 
-In this example we use the paintbrush and fill bucket tools in the `Labels` to separate two regions that were incorrectly merged and two add two regions that were missed.
+In this example we use the paintbrush and fill bucket tools in the `Labels`
+to separate two regions that were incorrectly merged and two add two regions that were missed.
 
 ### mesoscope neural imaging data
 
 ![image](./assets/gallery/mesoscope.gif)
 
-This example shows neural activity recorded with the [2-photon random access mesoscope](https://elifesciences.org/articles/14472). The bottom `Image` layer contains the underlying timeseries of neural activity. The subsequent `Image` layers contain processed maps, such as the mean, local correlation or colored correlations with other timeseries data.
+This example shows neural activity recorded with the [2-photon random access mesoscope](https://elifesciences.org/articles/14472).
+The bottom `Image` layer contains the underlying timeseries of neural activity.
+The subsequent `Image` layers contain processed maps,
+such as the mean, local correlation or colored correlations with other timeseries data.
 
 ### electron microscopy data
 
 ![image](./assets/gallery/CREMI.gif)
 
-This example shows 3D electron microscopy data from the [CREMI](https://cremi.org/) circuit reconstruction challenge. The bottom `Image` layer contains the underlying electron microscopy image. The `Labels` layer immediately above it contains the segmentation mask, where each colored region corresponds to one neuron. Pre- and post-synaptic sites are marked with `Points` layers.
+This example shows 3D electron microscopy data from the [CREMI](https://cremi.org/) circuit reconstruction challenge.
+The bottom `Image` layer contains the underlying electron microscopy image.
+The `Labels` layer immediately above it contains the segmentation mask,
+where each colored region corresponds to one neuron.
+Pre- and post-synaptic sites are marked with `Points` layers.
 
 ### allen brain reference atlas
 
 ![image](./assets/gallery/allen_brain.gif)
 
-This example shows the [allen brain reference atlas](https://mouse.brain-map.org/static/atlas), a 3D map of the mouse brain, including its division into different brain areas. The bottom `Image` layer contains the underlying grayscale representation of the reference brain, and the top `Labels` layer contains the divisions into different brain regions, where each colored region corresponds to a different part of the brain.
+This example shows the [allen brain reference atlas](https://mouse.brain-map.org/static/atlas),
+a 3D map of the mouse brain, including its division into different brain areas.
+The bottom `Image` layer contains the underlying grayscale representation of the reference brain,
+and the top `Labels` layer contains the divisions into different brain regions,
+where each colored region corresponds to a different part of the brain.
 
 ### image-based transcriptomic data
 
 ![image](./assets/gallery/smFISH.gif)
 
-This examples shows some image-based transcriptomics data analyzed with the [starfish tool](https://spacetx-starfish.readthedocs.io/en/latest/). Each spot in the image corresponds to an mRNA molecule. The bottom `Image` layer is the raw image data. The middle `Image` layer is the raw data after a learnt deconvolution, and the top `Points` layer corresponds to the detected mRNA spots.
+This examples shows some image-based transcriptomics data analyzed with the [starfish tool](https://spacetx-starfish.readthedocs.io/en/latest/).
+Each spot in the image corresponds to an mRNA molecule.
+The bottom `Image` layer is the raw image data.
+The middle `Image` layer is the raw data after a learnt deconvolution,
+and the top `Points` layer corresponds to the detected mRNA spots.
 
 We can also visualize the raw and deconvolved layers as 3D volumes using the `Volume` layer.
 
 ![image](./assets/gallery/smFISH_3D.gif)
 
-Here the raw volume is shown in a `red` colormap, and the deconvolved volume is shown in a `green` colormap.
+Here the raw volume is shown in a `red` colormap,
+and the deconvolved volume is shown in a `green` colormap.
 
 Data courtesy of Tim Wang, Svoboda Lab.
 
@@ -79,7 +114,11 @@ Data courtesy of Tim Wang, Svoboda Lab.
 
 ![image](./assets/gallery/allen_cell.gif)
 
-This examples shows images of cells under brightfield and fluorescent imaging. There are four color channels of flourescently label data all blended together, showing the cell nuclei and the distribution of targets of interest. The top `Labels` layer shows some hand drawn regions around the nuclei, which can been seen in blue.
+This examples shows images of cells under brightfield and fluorescent imaging.
+There are four color channels of flourescently label data all blended together,
+showing the cell nuclei and the distribution of targets of interest.
+The top `Labels` layer shows some hand drawn regions around the nuclei,
+which can been seen in blue.
 
 We can also visualize the flourescent data as `Volume` layers too.
 
@@ -91,15 +130,23 @@ Data from Allen Cell.
 
 ![image](./assets/gallery/cells.gif)
 
-This example shows 3 color channels of data of cell nuclei, membranes, and cytoplasm represented using three different `Image` layers with different colormaps, blended together. The top `Points` layer contains markers over the centers of the cell nuclei. The second from the top `Shapes` layer, contains polygon representations of the boundaries of the cells. Data from ImageJ examples.
+This example shows 3 color channels of data of cell nuclei, membranes, and cytoplasm
+represented using three different `Image` layers with different colormaps, blended together.
+The top `Points` layer contains markers over the centers of the cell nuclei.
+The second from the top `Shapes` layer,
+contains polygon representations of the boundaries of the cells.
+Data from ImageJ examples.
 
-During the example we edit the position of some of the points, and shapes, including deleting existing ones and adding new ones.
+During the example we edit the position of some of the points and shapes,
+including deleting existing ones and adding new ones.
 
 ### volumetric rendering data
 
 ![image](./assets/gallery/stent.gif)
 
-This example shows 3D rendering of a stent, and includes the changing of colormaps and color limits. Data from vispy examples.
+This example shows 3D rendering of a stent,
+and includes the changing of colormaps and color limits.
+Data from vispy examples.
 
 ### geospatial data
 
@@ -111,9 +158,15 @@ This example shows data from the [landsat-8](https://landsat.gsfc.nasa.gov/lands
 
 ![image](./assets/gallery/DSB2018_browse.gif)
 
-This example browses data from the [2018 kaggle data science bowl](https://www.kaggle.com/c/data-science-bowl-2018) on nuclei segmentation. The raw images are visualized using an `Image` layer and the segmentations are visualized using a `Labels` layer.
+This example browses data from the [2018 kaggle data science bowl](https://www.kaggle.com/c/data-science-bowl-2018) on nuclei segmentation.
+The raw images are visualized using an `Image` layer
+and the segmentations are visualized using a `Labels` layer.
 
-We are using [dask-image](https://dask-image.readthedocs.io) to look at directories of the images and labels and lazily them when requested by the slider. This method can support easy browsing of training datasets with many many examples as we never need to load all the images into memory. Note that not all images need to be the same size either.
+We are using [dask-image](https://dask-image.readthedocs.io) to look at directories of the images
+and labels and lazily them when requested by the slider.
+This method can support easy browsing of training datasets with many many examples
+as we never need to load all the images into memory.
+Note that not all images need to be the same size either.
 
 We can also edit or create our own segmentations using the paintbrush and fill bucket tool in the `Labels` layer.
 
@@ -123,6 +176,12 @@ We can also edit or create our own segmentations using the paintbrush and fill b
 
 ![image](./assets/gallery/ants_bees.gif)
 
-This example shows data from a [hymenoptera classification task](https://pytorch.org/tutorials/beginner/transfer_learning_tutorial.html) where the goal is to separate the images of the ants and bees. Here we are using [dask-image](https://dask-image.readthedocs.io) to look at two directories of images and lazily load each image when requested by the slider. This method can support easy browsing of training datasets with many many images as we never need to load all the images into memory. Note that not all images need to be the same size either.
+This example shows data from a [hymenoptera classification task](https://pytorch.org/tutorials/beginner/transfer_learning_tutorial.html)
+where the goal is to separate the images of the ants and bees.
+Here we are using [dask-image](https://dask-image.readthedocs.io) to look at two directories of images
+and lazily load each image when requested by the slider.
+This method can support easy browsing of training datasets with many many images
+as we never need to load all the images into memory.
+Note that not all images need to be the same size either.
 
 {% include footer.md %}

--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ You can follow progress on this repository,
 test out new versions as we release them,
 and contribute ideas and code.
 
-To get a sense of our current plans checkout and contribute to the discussion on some of our [long-term feature issues](https://github.com/napari/napari/issues?q=is%3Aissue+is%3Aopen+label%3A%22long-term+feature%22) on gitub.
+To get a sense of our current plans checkout and contribute to the discussion on some of our [long-term feature issues](https://github.com/napari/napari/issues?q=is%3Aissue+is%3Aopen+label%3A%22long-term+feature%22) on Github.
 
 To checkout some cool example uses of **napari** with scientific data see our [gallery](./gallery).
 
@@ -35,7 +35,8 @@ To checkout some cool example uses of **napari** with scientific data see our [g
 These tutorials target people who want to use napari as a user.
 If you are also interested in contributing to napari then please check out [contributing guidelines](https://github.com/napari/napari/blob/master/docs/developers/CONTRIBUTING.md).
 
-If you've already got napari installed then begin with our [getting started](./fundamentals/getting_started) tutorial.
+If you've already got napari installed,
+then begin with our [getting started](./fundamentals/getting_started) tutorial.
 For help installing napari checkout our [installing napari](./fundamentals/installation) tutorial.
 
 ## help

--- a/index.md
+++ b/index.md
@@ -1,17 +1,30 @@
 # napari tutorials
 
-Welcome to the **napari** tutorials! Our main development occurs on the
-[napari/napari](https://github.com/napari/napari)
-repository. Here we've provided a few tutorials to
-explore the main usage modes and methods of napari. Before we dive in, let's talk a bit about what napari actually is and why we're developing it.
+Welcome to the **napari** tutorials!
+Our main development occurs on the [napari/napari](https://github.com/napari/napari) repository.
+Here we've provided a few tutorials to explore the main usage modes and methods of napari.
+Before we dive in, let's talk a bit about what napari actually is and why we're developing it.
 
 ## what is napari?
 
-**napari** is a fast, interactive, multi-dimensional image viewer for Python. It's designed for browsing, annotating, and analyzing large multi-dimensional images. It's built on top of `Qt` (for the GUI), `vispy` (for performant GPU-based rendering), and the scientific Python stack (e.g. `numpy`, `scipy`). It includes critical viewer features out-of-the-box, such as support for large multi-dimensional data, and layering and annotation. By integrating closely with the Python ecosystem, **napari** can be easily coupled to leading machine learning and image analysis tools (e.g. `scikit-image`, `scikit-learn`, `TensorFlow`, `PyTorch`), enabling more user-friendly automated analysis.
+**napari** is a fast, interactive, multi-dimensional image viewer for Python.
+It's designed for browsing, annotating, and analyzing large multi-dimensional images.
+It's built on top of `Qt` (for the GUI), `vispy` (for performant GPU-based rendering),
+and the scientific Python stack (e.g. `numpy`, `scipy`).
+It includes critical viewer features out-of-the-box,
+such as support for large multi-dimensional data, and layering and annotation.
+By integrating closely with the Python ecosystem,
+**napari** can be easily coupled to leading machine learning and image analysis tools (e.g. `scikit-image`, `scikit-learn`, `TensorFlow`, `PyTorch`),
+enabling more user-friendly automated analysis.
 
 ![image](./assets/tutorials/napari_overview.png)
 
-We're developing **napari** in the open! But the project is in an **alpha** stage, and there will still likely be **breaking changes** with each release. You can follow progress on this repository, test out new versions as we release them, and contribute ideas and code.
+We're developing **napari** in the open!
+But the project is in an **alpha** stage,
+and there will still likely be **breaking changes** with each release.
+You can follow progress on this repository,
+test out new versions as we release them,
+and contribute ideas and code.
 
 To get a sense of our current plans checkout and contribute to the discussion on some of our [long-term feature issues](https://github.com/napari/napari/issues?q=is%3Aissue+is%3Aopen+label%3A%22long-term+feature%22) on gitub.
 
@@ -19,19 +32,23 @@ To checkout some cool example uses of **napari** with scientific data see our [g
 
 ## getting started
 
-These tutorials target people who want to use
-napari as a user. If you are also interested in contributing to napari then
-please check out [contributing guidelines](https://github.com/napari/napari/blob/master/docs/developers/CONTRIBUTING.md).
+These tutorials target people who want to use napari as a user.
+If you are also interested in contributing to napari then please check out [contributing guidelines](https://github.com/napari/napari/blob/master/docs/developers/CONTRIBUTING.md).
 
-If you've already got napari installed then begin with our [getting started](./fundamentals/getting_started) tutorial. For help installing napari checkout our [installing napari](./fundamentals/installation) tutorial.
+If you've already got napari installed then begin with our [getting started](./fundamentals/getting_started) tutorial.
+For help installing napari checkout our [installing napari](./fundamentals/installation) tutorial.
 
 ## help
 
-We're a community partner on the [imagesc forum](https://forum.image.sc/tags/napari) and all help and support requests should be posted on the forum with the tag `napari`. We look forward to interacting with you there.
+We're a community partner on the [imagesc forum](https://forum.image.sc/tags/napari) and all help and support requests should be posted on the forum with the tag `napari`.
+We look forward to interacting with you there.
 
 ## improving the tutorials
 
-Our tutorials are hosted on Github at [napari/tutorials](https://github.com/napari/tutorials). If as you're going through the tutorials you spot any errors or can think of ways to improve them please raise an issue on the repository or make a PR, we'd love to have the community help make them better for everyone.
+Our tutorials are hosted on Github at [napari/tutorials](https://github.com/napari/tutorials).
+If as you're going through the tutorials you spot any errors or can think of ways to improve them
+please raise an issue on the repository or make a PR,
+we'd love to have the community help make them better for everyone.
 
 [napari tutorials home page](http://www.napari.org/tutorials)
 


### PR DESCRIPTION
This pull request:
- Addresses issues raised by `markdownlint`
- Adds semantic line breaks
- Fixes typos and grammar identified by `codespell` and `MS Word`

I added line breaks after each sentence, and when obvious after clauses separated by a comma.
I tried to break up lines that were especially long, and tried to add breaks when one might take a breath, but it wasn't 100% objective for me. If a sentence could not be broken up, and was longer than 80 characters, I left it as-is

This matter is certainly update for a debate, and hopefully makes the docs easier to maintain.

This resolves #78 